### PR TITLE
feat: admin CRUD, A/B testing framework, and prompt TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5433/prompt_service?schema=public"
 
-# API Keys (comma-separated list of valid keys)
+# API Keys (comma-separated list of valid keys for node access)
 API_KEYS="dev-key-1,dev-key-2"
+
+# Admin API Keys (comma-separated, separate from node API keys)
+ADMIN_API_KEYS="admin-dev-key-1"
+
+# Prompt TTL in seconds (how long nodes should cache prompts before re-fetching)
+PROMPT_TTL_SECONDS=3600
 
 # Server
 PORT=3100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,48 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lint-test-build:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
+
+      - name: Run linting
+        run: pnpm lint
+
+  test:
+    name: Test
     runs-on: ubuntu-latest
 
     services:
@@ -32,19 +67,24 @@ jobs:
       PROMPT_TTL_SECONDS: 3600
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
         with:
-          node-version: 20
-          cache: pnpm
+          node-version: '20'
+          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma client
         run: pnpm db:generate
@@ -52,11 +92,40 @@ jobs:
       - name: Run migrations
         run: pnpm db:migrate:deploy
 
-      - name: Lint
-        run: pnpm lint
-
-      - name: Test
+      - name: Run tests with coverage
         run: pnpm test:cov
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: coverage-reports
+          path: coverage/
+          retention-days: 1
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm db:generate
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/prompt_service_test?schema=public
       API_KEYS: test-key-1,test-key-2
+      ADMIN_API_KEYS: admin-test-key-1
+      PROMPT_TTL_SECONDS: 3600
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -1,0 +1,24 @@
+name: Validate Main PR
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Verify PR from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "::error::PRs to main must come from the develop branch"
+            echo ""
+            echo "Current source branch: ${{ github.head_ref }}"
+            echo ""
+            echo "To fix this:"
+            echo "1. Merge your changes to develop first"
+            echo "2. Create a PR from develop to main"
+            exit 1
+          fi
+          echo "PR is from develop branch - allowed"

--- a/README.md
+++ b/README.md
@@ -81,15 +81,36 @@ curl -X POST http://localhost:3100/prompts/document-analysis \
 
 ## API Endpoints
 
-All prompt endpoints require a Bearer token (`Authorization: Bearer <API_KEY>`).
+### Prompt Serving (Node API Key)
 
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `GET` | `/health` | No | Service health check |
-| `POST` | `/prompts/structural-analysis` | Yes | Web scraping extraction prompt |
-| `POST` | `/prompts/document-analysis` | Yes | Document analysis prompt |
-| `POST` | `/prompts/rag` | Yes | RAG answer generation prompt |
-| `POST` | `/prompts/verify` | Yes | Verify a prompt hash is authentic |
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Service health check (no auth) |
+| `POST` | `/prompts/structural-analysis` | Web scraping extraction prompt |
+| `POST` | `/prompts/document-analysis` | Document analysis prompt |
+| `POST` | `/prompts/rag` | RAG answer generation prompt |
+| `POST` | `/prompts/verify` | Verify a prompt hash is authentic |
+
+### Admin: Template Management (Admin API Key)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/admin/templates` | List templates (with optional filters) |
+| `GET` | `/admin/templates/:id` | Get template with version history |
+| `POST` | `/admin/templates` | Create new template |
+| `PATCH` | `/admin/templates/:id` | Update template (auto-versions) |
+| `DELETE` | `/admin/templates/:id` | Soft-delete template |
+| `POST` | `/admin/templates/:id/rollback` | Rollback to previous version |
+
+### Admin: A/B Experiments (Admin API Key)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/admin/experiments` | Create experiment (draft) |
+| `GET` | `/admin/experiments` | List all experiments |
+| `GET` | `/admin/experiments/:id` | Get experiment details |
+| `POST` | `/admin/experiments/:id/activate` | Activate experiment |
+| `POST` | `/admin/experiments/:id/stop` | Stop experiment |
 
 Interactive API docs are available at `http://localhost:3100/api` (Swagger UI).
 
@@ -100,7 +121,9 @@ See [docs/api-reference.md](docs/api-reference.md) for full request/response sch
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string |
-| `API_KEYS` | Yes | — | Comma-separated list of valid API keys |
+| `API_KEYS` | Yes | — | Comma-separated list of valid node API keys |
+| `ADMIN_API_KEYS` | Yes | — | Comma-separated list of valid admin API keys |
+| `PROMPT_TTL_SECONDS` | No | `3600` | Prompt expiry TTL in seconds (nodes must re-fetch after) |
 | `PORT` | No | `3100` | Server port |
 
 ## Scripts
@@ -124,11 +147,12 @@ See [docs/api-reference.md](docs/api-reference.md) for full request/response sch
 ```
 prompt-service/
 ├── prisma/
-│   ├── schema.prisma          # Database schema
+│   ├── schema.prisma          # Database schema (templates, versions, experiments)
 │   └── seed.ts                # Seeds all 13 prompt templates
 ├── src/
 │   ├── auth/
-│   │   └── api-key.guard.ts   # Bearer token validation
+│   │   ├── api-key.guard.ts   # Node API key validation
+│   │   └── admin-key.guard.ts # Admin API key validation
 │   ├── common/
 │   │   ├── prisma.module.ts   # Global Prisma provider
 │   │   └── prisma.service.ts  # Prisma client lifecycle
@@ -138,7 +162,16 @@ prompt-service/
 │   │   ├── dto/               # Request validation DTOs
 │   │   ├── prompts.controller.ts  # Route handlers
 │   │   ├── prompts.module.ts
-│   │   └── prompts.service.ts # Template lookup, interpolation, hashing
+│   │   └── prompts.service.ts # Template lookup, A/B resolution, interpolation, hashing
+│   ├── admin/
+│   │   ├── dto/               # Admin request DTOs (create, update, rollback, experiment)
+│   │   ├── admin.controller.ts           # Template CRUD endpoints
+│   │   ├── experiments-admin.controller.ts  # Experiment lifecycle endpoints
+│   │   ├── admin.service.ts   # Template & experiment business logic
+│   │   └── admin.module.ts
+│   ├── experiments/
+│   │   ├── experiments.service.ts   # A/B bucketing engine
+│   │   └── experiments.module.ts    # Global experiment provider
 │   ├── app.module.ts          # Root module
 │   └── main.ts                # Bootstrap + Swagger setup
 ├── docker-compose.yml         # Local dev stack

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,9 +17,9 @@ Opus Populi follows a "glass box behavior, black box implementation" model:
 
 ## Authentication & Authorization
 
-### API Key Authentication
+### Node API Key Authentication
 
-All prompt endpoints require a Bearer token in the `Authorization` header:
+All prompt-serving endpoints require a Bearer token in the `Authorization` header:
 
 ```
 Authorization: Bearer <API_KEY>
@@ -28,7 +28,20 @@ Authorization: Bearer <API_KEY>
 - API keys are configured via the `API_KEYS` environment variable (comma-separated)
 - Keys are validated by `ApiKeyGuard` (`src/auth/api-key.guard.ts`)
 - Invalid or missing tokens return `401 Unauthorized`
-- The API key is attached to the request context for analytics logging
+- The API key is attached to the request context for analytics logging and A/B experiment bucketing
+
+### Admin API Key Authentication
+
+Template management and experiment control endpoints require a **separate** set of admin keys:
+
+```
+Authorization: Bearer <ADMIN_API_KEY>
+```
+
+- Admin keys are configured via the `ADMIN_API_KEYS` environment variable (comma-separated)
+- Keys are validated by `AdminKeyGuard` (`src/auth/admin-key.guard.ts`)
+- Node API keys **cannot** access admin endpoints, and admin keys **cannot** access prompt-serving endpoints
+- This separation ensures a compromised node cannot modify templates or experiments
 
 ### What is logged
 
@@ -36,6 +49,7 @@ Every prompt request logs:
 - Endpoint called (`structural-analysis`, `document-analysis`, `rag`)
 - Prompt template version served
 - API key prefix (first 8 characters + `...`) — **not the full key**
+- A/B experiment ID and variant name (if the request was part of an experiment)
 - Timestamp
 
 Full API keys are **never** written to logs or the database.
@@ -77,6 +91,15 @@ Every template change is recorded in the `prompt_version_history` table with:
 - Timestamp
 
 This creates an immutable audit trail. No version record can be deleted (enforced by the schema — no delete endpoint exists).
+
+### Experiment Audit Trail
+
+A/B experiments are fully auditable:
+- Every experiment records its creation time, activation time, and stop time
+- Each variant links to a specific version history entry (immutable reference)
+- Every prompt request logs which experiment and variant it was served under
+- Rollback to a previous version creates a **new** version entry, preserving the full history
+- Experiments can only be stopped, never deleted — the full experiment lifecycle is preserved
 
 ## Data Handling
 
@@ -164,6 +187,8 @@ In the federated Opus Populi network:
 | Threat | Mitigation |
 |--------|-----------|
 | Unauthorized prompt access | Bearer token authentication; API keys rotatable |
+| Unauthorized template modification | Separate admin API keys; node keys cannot access admin endpoints |
+| Experiment tampering | Admin-only experiment controls; immutable variant-to-version linkage |
 | Prompt scraping | Rate limiting (30 req/min per endpoint per key) |
 | Prompt tampering in transit | SHA-256 hash verification via `/prompts/verify` |
 | Node modifying prompts locally | Prompt lock verification in `prompt-client` (planned, see Issue #426) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     environment:
       DATABASE_URL: postgresql://postgres:postgres@prompt-db:5432/prompt_service?schema=public
       API_KEYS: dev-key-1,dev-key-2
+      ADMIN_API_KEYS: admin-dev-key-1
+      PROMPT_TTL_SECONDS: 3600
       PORT: 3100
     depends_on:
       prompt-db:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -22,6 +22,14 @@ API keys are configured via the `API_KEYS` environment variable (comma-separated
 }
 ```
 
+### Admin Authentication
+
+Admin endpoints (`/admin/*`) use a separate set of API keys configured via the `ADMIN_API_KEYS` environment variable. This separation ensures that node API keys cannot access template management or experiment controls.
+
+```
+Authorization: Bearer <ADMIN_API_KEY>
+```
+
 ## Rate Limits
 
 | Scope | Limit | Window |
@@ -87,7 +95,8 @@ Returns a rendered prompt for web page structural analysis (scraping pipeline).
 {
   "promptText": "You are a web scraping expert. Analyze the following HTML...",
   "promptHash": "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890",
-  "promptVersion": "v1"
+  "promptVersion": "v1",
+  "expiresAt": "2026-02-25T13:00:00.000Z"
 }
 ```
 
@@ -123,7 +132,8 @@ Returns a rendered prompt for document analysis (petition scanning, proposition 
 {
   "promptText": "You are a nonpartisan civic analyst. Analyze this petition...\nRespond with valid JSON only. No markdown, no explanations.",
   "promptHash": "b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890a1",
-  "promptVersion": "v1"
+  "promptVersion": "v1",
+  "expiresAt": "2026-02-25T13:00:00.000Z"
 }
 ```
 
@@ -169,7 +179,8 @@ Returns a rendered prompt for RAG (Retrieval-Augmented Generation) answer genera
 {
   "promptText": "You are a helpful assistant that answers questions based only on the provided context...",
   "promptHash": "c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890a1b2",
-  "promptVersion": "v1"
+  "promptVersion": "v1",
+  "expiresAt": "2026-02-25T13:00:00.000Z"
 }
 ```
 
@@ -216,6 +227,189 @@ The service looks up all templates matching the given version, computes the SHA-
 
 ---
 
+---
+
+## Admin: Template Management
+
+All admin endpoints require an admin API key (`ADMIN_API_KEYS`).
+
+### `GET /admin/templates`
+
+List all templates with optional filters.
+
+#### Query Parameters
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `category` | string | Filter by category (e.g., `structural_analysis`) |
+| `isActive` | boolean | Filter by active status |
+
+#### Response
+
+```json
+[
+  {
+    "id": "uuid",
+    "name": "document-analysis-petition",
+    "category": "document_analysis",
+    "description": "Nonpartisan petition analysis",
+    "templateText": "You are a nonpartisan civic analyst...",
+    "variables": ["TEXT"],
+    "version": 3,
+    "isActive": true,
+    "createdAt": "2026-01-15T10:00:00.000Z",
+    "updatedAt": "2026-02-20T14:30:00.000Z"
+  }
+]
+```
+
+### `GET /admin/templates/:id`
+
+Get a template by ID, including its full version history.
+
+#### Response
+
+```json
+{
+  "id": "uuid",
+  "name": "document-analysis-petition",
+  "version": 3,
+  "versionHistory": [
+    {
+      "id": "uuid",
+      "version": 3,
+      "templateText": "...",
+      "templateHash": "abc123...",
+      "changeNote": "Improved neutrality language",
+      "createdAt": "2026-02-20T14:30:00.000Z"
+    },
+    {
+      "id": "uuid",
+      "version": 2,
+      "templateText": "...",
+      "templateHash": "def456...",
+      "changeNote": "Added beneficiary analysis",
+      "createdAt": "2026-02-10T09:00:00.000Z"
+    }
+  ]
+}
+```
+
+### `POST /admin/templates`
+
+Create a new prompt template. Automatically creates an initial version history entry.
+
+#### Request Body
+
+```json
+{
+  "name": "document-analysis-ballot-measure",
+  "category": "document_analysis",
+  "description": "Ballot measure analysis template",
+  "templateText": "You are a nonpartisan civic analyst. Analyze the following ballot measure:\n\n{{TEXT}}",
+  "variables": ["TEXT"],
+  "changeNote": "Initial creation"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Lowercase with hyphens only (e.g., `my-template-name`) |
+| `category` | string | Yes | Template category |
+| `description` | string | Yes | Human-readable purpose |
+| `templateText` | string | Yes | Template with `{{VARIABLE}}` placeholders |
+| `variables` | string[] | No | List of expected variable names |
+| `changeNote` | string | No | Defaults to "Initial creation" |
+
+### `PATCH /admin/templates/:id`
+
+Update an existing template. Increments the version number and creates a version history entry.
+
+#### Request Body
+
+```json
+{
+  "templateText": "Updated template text with {{TEXT}} placeholder",
+  "changeNote": "Improved extraction accuracy"
+}
+```
+
+All fields are optional except `changeNote`. Only provided fields are updated.
+
+### `DELETE /admin/templates/:id`
+
+Soft-delete a template (sets `isActive: false`). The template and its history are preserved.
+
+### `POST /admin/templates/:id/rollback`
+
+Rollback a template to a previous version. Creates a new version entry (does not rewrite history).
+
+#### Request Body
+
+```json
+{
+  "targetVersion": 2,
+  "changeNote": "Reverting due to accuracy regression"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `targetVersion` | integer | Yes | Version number to rollback to (minimum: 1) |
+| `changeNote` | string | No | Defaults to "Rollback to version N" |
+
+---
+
+## Admin: A/B Experiments
+
+Experiment endpoints manage A/B tests that serve different prompt versions to different nodes based on deterministic bucketing.
+
+### `POST /admin/experiments`
+
+Create a new experiment in `draft` status.
+
+#### Request Body
+
+```json
+{
+  "name": "petition-prompt-v3-test",
+  "description": "Test improved neutrality language",
+  "templateId": "uuid-of-template",
+  "variants": [
+    { "name": "control", "versionId": "uuid-of-version-history-entry", "trafficPct": 50 },
+    { "name": "variant_a", "versionId": "uuid-of-version-history-entry", "trafficPct": 50 }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Unique experiment name |
+| `description` | string | No | Experiment description |
+| `templateId` | UUID | Yes | Template this experiment applies to |
+| `variants` | array | Yes | Minimum 2 variants; `trafficPct` must sum to 100 |
+| `variants[].name` | string | Yes | Variant name (e.g., "control", "variant_a") |
+| `variants[].versionId` | UUID | Yes | ID of a `PromptVersionHistory` entry |
+| `variants[].trafficPct` | integer | Yes | Traffic percentage (0-100) |
+
+### `GET /admin/experiments`
+
+List all experiments with their variants and linked templates.
+
+### `GET /admin/experiments/:id`
+
+Get experiment details including variants with their associated version entries.
+
+### `POST /admin/experiments/:id/activate`
+
+Activate a draft experiment. Only one experiment may be active per template at a time. Returns `400` if the experiment is not in `draft` status or another experiment is already active for the same template.
+
+### `POST /admin/experiments/:id/stop`
+
+Stop an active experiment. Sets status to `stopped` and records `stoppedAt` timestamp. Once stopped, the template reverts to serving its default (latest) version.
+
+---
+
 ## Common Response Format
 
 All prompt endpoints return the same shape:
@@ -228,6 +422,8 @@ interface PromptServiceResponse {
   promptHash: string;
   /** Template version identifier (e.g., "v1") */
   promptVersion: string;
+  /** ISO 8601 expiry timestamp — nodes must re-fetch after this time */
+  expiresAt: string;
 }
 ```
 
@@ -235,6 +431,8 @@ The `promptHash` is computed from the template **before** variable interpolation
 - The same template always produces the same hash regardless of input
 - The hash changes only when the template itself is edited
 - Hashes can be verified via the `/prompts/verify` endpoint
+
+The `expiresAt` field is computed as `now + PROMPT_TTL_SECONDS` (default: 3600 seconds / 1 hour). Nodes should re-fetch prompts after the expiry time to pick up template updates.
 
 ## Error Responses
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,8 @@ The Prompt Service is a standalone NestJS microservice that serves AI prompt tem
 │  Response contract (shared):     │     │  Same contract:                  │
 │  { promptText,                   │     │  { promptText,                   │
 │    promptHash,                   │     │    promptHash,                   │
-│    promptVersion }               │     │    promptVersion }               │
+│    promptVersion,                │     │    promptVersion,                │
+│    expiresAt }                   │     │    expiresAt }                   │
 └──────────────────────────────────┘     └──────────────────────────────────┘
 ```
 
@@ -42,10 +43,15 @@ AppModule
 ├── ConfigModule (global)           # Environment variables
 ├── ThrottlerModule (global)        # Rate limiting: 60 req/min default
 ├── PrismaModule (global)           # Database connection lifecycle
+├── ExperimentsModule (global)      # A/B testing bucketing engine
 ├── HealthModule                    # GET /health
-└── PromptsModule                   # All prompt endpoints
-    ├── PromptsController           # Route handlers + auth guards
-    └── PromptsService              # Template lookup, interpolation, hashing, logging
+├── PromptsModule                   # Prompt serving endpoints
+│   ├── PromptsController           # Route handlers + node API key guards
+│   └── PromptsService              # Template lookup, A/B resolution, interpolation, hashing
+└── AdminModule                     # Template & experiment management
+    ├── AdminController             # CRUD for templates (admin key auth)
+    ├── ExperimentsAdminController  # Experiment lifecycle (admin key auth)
+    └── AdminService                # Template CRUD, rollback, experiment management
 ```
 
 ## Database Schema
@@ -81,9 +87,36 @@ Immutable audit trail of every template change.
 | `change_note` | String? | What changed and why |
 | `created_at` | Timestamptz | When this version was created |
 
+### `experiments`
+
+A/B testing experiments that serve different prompt versions to different nodes.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key |
+| `name` | String (unique) | Experiment identifier |
+| `description` | String? | Human-readable purpose |
+| `template_id` | UUID | FK to `prompt_templates` — template being tested |
+| `status` | String | `draft`, `active`, or `stopped` |
+| `created_at` | Timestamptz | Creation timestamp |
+| `updated_at` | Timestamptz | Last modification timestamp |
+| `stopped_at` | Timestamptz? | When the experiment was stopped |
+
+### `experiment_variants`
+
+Variant definitions within an experiment. Traffic percentages must sum to 100.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key |
+| `experiment_id` | UUID | FK to `experiments` |
+| `name` | String | Variant name (e.g., "control", "variant_a") |
+| `version_id` | UUID | FK to `prompt_version_history` — which template version to serve |
+| `traffic_pct` | Int | Traffic percentage (0-100) |
+
 ### `prompt_request_logs`
 
-Analytics table tracking prompt usage.
+Analytics table tracking prompt usage, including A/B experiment participation.
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -91,6 +124,8 @@ Analytics table tracking prompt usage.
 | `endpoint` | String | Which endpoint was called |
 | `prompt_version` | Int | Template version served |
 | `api_key_prefix` | String | First 8 chars of API key (for identification without exposure) |
+| `experiment_id` | String? | Experiment ID if request was part of an A/B test |
+| `variant_name` | String? | Variant name served (e.g., "control", "variant_a") |
 | `created_at` | Timestamptz | Request timestamp |
 
 ## Request Flow
@@ -112,16 +147,20 @@ Analytics table tracking prompt usage.
    → 400 if invalid
 
 5. PromptsService.getDocumentAnalysisPrompt():
-   a. Look up template: "document-analysis-petition"
+   a. resolveTemplate("document-analysis-petition", apiKey):
+      i.  Check for active A/B experiment on this template
+      ii. If experiment active → bucket API key to variant → use variant's template text
+      iii.If no experiment → look up default template
       → If not found, fall back to "document-analysis-generic"
       → If neither found, throw 404
-   b. Look up base instructions: "document-analysis-base-instructions"
+   b. Look up base instructions: "document-analysis-base-instructions" (always default, never A/B tested)
    c. Interpolate {{TEXT}} variable into template
    d. Append base instructions
    e. Compute SHA-256 hash of raw template text (before interpolation)
-   f. Log request to prompt_request_logs
+   f. Compute expiresAt from PROMPT_TTL_SECONDS config
+   g. Log request to prompt_request_logs (including experimentId and variantName if applicable)
 
-6. Return { promptText, promptHash, promptVersion }
+6. Return { promptText, promptHash, promptVersion, expiresAt }
 ```
 
 ### Verification Request
@@ -167,6 +206,52 @@ The Prompt Service uses a template fallback chain for type-specific lookups:
 3. If neither found, return `404 Not Found`
 
 This allows adding new document types by simply seeding a new template — no code changes required.
+
+## A/B Testing (Experiments)
+
+The service supports A/B testing of prompt templates via the experiments system. This allows controlled rollout of prompt changes by serving different template versions to different nodes.
+
+### Bucketing Algorithm
+
+Nodes are deterministically assigned to variants using SHA-256 hashing:
+
+```
+bucket = parseInt(SHA256(apiKey + ":" + experimentId)[0..7], 16) % 100
+```
+
+Properties:
+- **Deterministic**: The same node (API key) always gets the same variant for a given experiment
+- **Uniform**: SHA-256 distributes evenly across 0-99 buckets
+- **Independent**: Different experiments produce different bucket assignments for the same node
+
+### Experiment Lifecycle
+
+```
+draft → active → stopped
+```
+
+- **Draft**: Experiment is configured but not serving traffic. Variants and traffic splits can be adjusted.
+- **Active**: Experiment is live. Only one experiment may be active per template at a time. Prompt requests for the associated template are routed through the bucketing engine.
+- **Stopped**: Experiment is concluded. The template reverts to serving its default (latest) version.
+
+### Data Flow
+
+```
+1. Node requests prompt for "document-analysis-petition"
+2. ExperimentsService checks for active experiment on this template
+3. If experiment active:
+   a. Compute bucket from SHA256(apiKey + ":" + experimentId)
+   b. Walk variants by cumulative trafficPct until bucket < cumulative
+   c. Return variant's version entry (templateText, version, hash)
+4. If no experiment: use default template (latest active version)
+5. Log request with experimentId + variantName for analytics
+```
+
+### Design Decisions
+
+- **Only primary templates are A/B tested**: Auxiliary templates (schema descriptions, base instructions) always use the default version. This keeps prompt composition predictable.
+- **Separate admin controller**: Experiment endpoints use `/admin/experiments` (not nested under `/admin/templates/:id`) to avoid route parameter conflicts.
+- **No auto-winner selection**: Experiments must be manually stopped and evaluated. Automatic winner selection is out of scope for the initial implementation.
 
 Note: The `prompt-client` in the main repo has its own 3-tier fallback:
 1. Remote service (this service) → 2. Local database → 3. Hardcoded fallbacks

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model PromptTemplate {
   updatedAt    DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
   versionHistory PromptVersionHistory[]
+  experiments    Experiment[]
 
   @@index([category])
   @@index([isActive])
@@ -35,7 +36,8 @@ model PromptVersionHistory {
   changeNote     String?  @map("change_note")
   createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz
 
-  template PromptTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  template           PromptTemplate      @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  experimentVariants ExperimentVariant[]
 
   @@index([templateId])
   @@index([templateHash])
@@ -47,10 +49,45 @@ model PromptRequestLog {
   endpoint      String
   promptVersion Int      @map("prompt_version")
   apiKeyPrefix  String   @map("api_key_prefix")
+  experimentId  String?  @map("experiment_id")
+  variantName   String?  @map("variant_name")
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   @@index([endpoint])
   @@index([apiKeyPrefix])
   @@index([createdAt])
   @@map("prompt_request_logs")
+}
+
+model Experiment {
+  id          String    @id @default(uuid())
+  name        String    @unique
+  description String?
+  templateId  String    @map("template_id")
+  status      String    @default("draft") // draft, active, stopped
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  stoppedAt   DateTime? @map("stopped_at") @db.Timestamptz
+
+  template PromptTemplate      @relation(fields: [templateId], references: [id], onDelete: Cascade)
+  variants ExperimentVariant[]
+
+  @@index([templateId])
+  @@index([status])
+  @@map("experiments")
+}
+
+model ExperimentVariant {
+  id           String   @id @default(uuid())
+  experimentId String   @map("experiment_id")
+  name         String   // e.g., "control", "variant_a"
+  versionId    String   @map("version_id")
+  trafficPct   Int      @map("traffic_pct") // 0-100, must sum to 100 per experiment
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  experiment   Experiment           @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  versionEntry PromptVersionHistory @relation(fields: [versionId], references: [id])
+
+  @@index([experimentId])
+  @@map("experiment_variants")
 }

--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,0 +1,106 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: {
+            listTemplates: jest.fn(),
+            getTemplateById: jest.fn(),
+            createTemplate: jest.fn(),
+            updateTemplate: jest.fn(),
+            deleteTemplate: jest.fn(),
+            rollbackTemplate: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('admin-test-key') },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AdminController);
+    service = module.get(AdminService);
+  });
+
+  it('should call listTemplates with query', async () => {
+    const query = { category: 'rag' };
+    const expected = [{ id: '1', name: 'rag' }];
+    jest.spyOn(service, 'listTemplates').mockResolvedValue(expected as never);
+
+    const result = await controller.list(query);
+
+    expect(service.listTemplates).toHaveBeenCalledWith(query);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getTemplateById with id', async () => {
+    const expected = { id: '1', name: 'test', versionHistory: [] };
+    jest.spyOn(service, 'getTemplateById').mockResolvedValue(expected as never);
+
+    const result = await controller.getById('1');
+
+    expect(service.getTemplateById).toHaveBeenCalledWith('1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call createTemplate with dto', async () => {
+    const dto = {
+      name: 'new',
+      category: 'rag',
+      description: 'desc',
+      templateText: 'text',
+    };
+    const expected = { id: '1', ...dto, version: 1 };
+    jest.spyOn(service, 'createTemplate').mockResolvedValue(expected as never);
+
+    const result = await controller.create(dto);
+
+    expect(service.createTemplate).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call updateTemplate with id and dto', async () => {
+    const dto = { templateText: 'updated', changeNote: 'change' };
+    const expected = { id: '1', version: 2 };
+    jest.spyOn(service, 'updateTemplate').mockResolvedValue(expected as never);
+
+    const result = await controller.update('1', dto);
+
+    expect(service.updateTemplate).toHaveBeenCalledWith('1', dto);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call deleteTemplate with id', async () => {
+    const expected = { id: '1', isActive: false };
+    jest.spyOn(service, 'deleteTemplate').mockResolvedValue(expected as never);
+
+    const result = await controller.delete('1');
+
+    expect(service.deleteTemplate).toHaveBeenCalledWith('1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call rollbackTemplate with id and dto', async () => {
+    const dto = { targetVersion: 1, changeNote: 'rollback' };
+    const expected = { id: '1', version: 3 };
+    jest
+      .spyOn(service, 'rollbackTemplate')
+      .mockResolvedValue(expected as never);
+
+    const result = await controller.rollback('1', dto);
+
+    expect(service.rollbackTemplate).toHaveBeenCalledWith('1', dto);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AdminKeyGuard } from '../auth/admin-key.guard';
+import { AdminService } from './admin.service';
+import { CreateTemplateDto } from './dto/create-template.dto';
+import { UpdateTemplateDto } from './dto/update-template.dto';
+import { ListTemplatesQueryDto } from './dto/list-templates.dto';
+import { RollbackTemplateDto } from './dto/rollback-template.dto';
+
+@ApiTags('admin')
+@Controller('admin/templates')
+@UseGuards(AdminKeyGuard)
+@ApiBearerAuth()
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List all prompt templates' })
+  async list(@Query() query: ListTemplatesQueryDto) {
+    return this.adminService.listTemplates(query);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get template by ID with version history' })
+  async getById(@Param('id') id: string) {
+    return this.adminService.getTemplateById(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new prompt template' })
+  @ApiResponse({ status: 201, description: 'Template created' })
+  async create(@Body() dto: CreateTemplateDto) {
+    return this.adminService.createTemplate(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a prompt template' })
+  async update(@Param('id') id: string, @Body() dto: UpdateTemplateDto) {
+    return this.adminService.updateTemplate(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({
+    summary: 'Soft-delete a prompt template (sets isActive=false)',
+  })
+  async delete(@Param('id') id: string) {
+    return this.adminService.deleteTemplate(id);
+  }
+
+  @Post(':id/rollback')
+  @ApiOperation({ summary: 'Rollback template to a previous version' })
+  async rollback(@Param('id') id: string, @Body() dto: RollbackTemplateDto) {
+    return this.adminService.rollbackTemplate(id, dto);
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { ExperimentsAdminController } from './experiments-admin.controller';
+import { AdminService } from './admin.service';
+
+@Module({
+  controllers: [AdminController, ExperimentsAdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,497 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { AdminService } from './admin.service';
+
+function createMockPrisma() {
+  const txMethods = {
+    promptTemplate: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    promptVersionHistory: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
+  };
+
+  return {
+    promptTemplate: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    promptVersionHistory: {
+      findUnique: jest.fn(),
+    },
+    experiment: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    $transaction: jest.fn((cb: (tx: typeof txMethods) => unknown) =>
+      cb(txMethods),
+    ),
+    _tx: txMethods,
+  };
+}
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new AdminService(prisma as never);
+  });
+
+  describe('listTemplates', () => {
+    it('should return all templates when no filters', async () => {
+      const templates = [
+        { id: '1', name: 'template-a' },
+        { id: '2', name: 'template-b' },
+      ];
+      prisma.promptTemplate.findMany.mockResolvedValue(templates);
+
+      const result = await service.listTemplates({});
+
+      expect(prisma.promptTemplate.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toEqual(templates);
+    });
+
+    it('should filter by category', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([]);
+
+      await service.listTemplates({ category: 'rag' });
+
+      expect(prisma.promptTemplate.findMany).toHaveBeenCalledWith({
+        where: { category: 'rag' },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('should filter by isActive', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([]);
+
+      await service.listTemplates({ isActive: true });
+
+      expect(prisma.promptTemplate.findMany).toHaveBeenCalledWith({
+        where: { isActive: true },
+        orderBy: { name: 'asc' },
+      });
+    });
+  });
+
+  describe('getTemplateById', () => {
+    it('should return template with version history', async () => {
+      const template = {
+        id: '1',
+        name: 'test',
+        versionHistory: [{ version: 2 }, { version: 1 }],
+      };
+      prisma.promptTemplate.findUnique.mockResolvedValue(template);
+
+      const result = await service.getTemplateById('1');
+
+      expect(result).toEqual(template);
+      expect(prisma.promptTemplate.findUnique).toHaveBeenCalledWith({
+        where: { id: '1' },
+        include: { versionHistory: { orderBy: { version: 'desc' } } },
+      });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma.promptTemplate.findUnique.mockResolvedValue(null);
+
+      await expect(service.getTemplateById('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('createTemplate', () => {
+    it('should create template and version history in transaction', async () => {
+      const dto = {
+        name: 'new-template',
+        category: 'rag',
+        description: 'A new template',
+        templateText: 'Hello {{NAME}}',
+        variables: ['NAME'],
+        changeNote: 'First version',
+      };
+
+      const created = { id: 'uuid-1', ...dto, version: 1, isActive: true };
+      prisma._tx.promptTemplate.create.mockResolvedValue(created);
+      prisma._tx.promptVersionHistory.create.mockResolvedValue({});
+
+      const result = await service.createTemplate(dto);
+
+      expect(result).toEqual(created);
+      expect(prisma._tx.promptTemplate.create).toHaveBeenCalledWith({
+        data: {
+          name: 'new-template',
+          category: 'rag',
+          description: 'A new template',
+          templateText: 'Hello {{NAME}}',
+          variables: ['NAME'],
+        },
+      });
+      expect(prisma._tx.promptVersionHistory.create).toHaveBeenCalledWith({
+        data: {
+          templateId: 'uuid-1',
+          version: 1,
+          templateText: 'Hello {{NAME}}',
+          templateHash: createHash('sha256')
+            .update('Hello {{NAME}}')
+            .digest('hex'),
+          changeNote: 'First version',
+        },
+      });
+    });
+
+    it('should default changeNote to "Initial creation"', async () => {
+      const dto = {
+        name: 'test',
+        category: 'rag',
+        description: 'desc',
+        templateText: 'text',
+      };
+
+      prisma._tx.promptTemplate.create.mockResolvedValue({
+        id: '1',
+        ...dto,
+        version: 1,
+      });
+      prisma._tx.promptVersionHistory.create.mockResolvedValue({});
+
+      await service.createTemplate(dto);
+
+      expect(prisma._tx.promptVersionHistory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ changeNote: 'Initial creation' }),
+        }),
+      );
+    });
+  });
+
+  describe('updateTemplate', () => {
+    it('should increment version and create history entry', async () => {
+      const existing = {
+        id: '1',
+        name: 'test',
+        templateText: 'old text',
+        version: 2,
+      };
+      const updated = { ...existing, templateText: 'new text', version: 3 };
+
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue(existing);
+      prisma._tx.promptTemplate.update.mockResolvedValue(updated);
+      prisma._tx.promptVersionHistory.create.mockResolvedValue({});
+
+      const result = await service.updateTemplate('1', {
+        templateText: 'new text',
+        changeNote: 'Updated prompt wording',
+      });
+
+      expect(result.version).toBe(3);
+      expect(prisma._tx.promptTemplate.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { version: 3, templateText: 'new text' },
+      });
+      expect(prisma._tx.promptVersionHistory.create).toHaveBeenCalledWith({
+        data: {
+          templateId: '1',
+          version: 3,
+          templateText: 'new text',
+          templateHash: createHash('sha256').update('new text').digest('hex'),
+          changeNote: 'Updated prompt wording',
+        },
+      });
+    });
+
+    it('should throw NotFoundException when template not found', async () => {
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateTemplate('nonexistent', {
+          changeNote: 'test',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('should set isActive to false', async () => {
+      const template = { id: '1', name: 'test', isActive: true };
+      prisma.promptTemplate.findUnique.mockResolvedValue(template);
+      prisma.promptTemplate.update.mockResolvedValue({
+        ...template,
+        isActive: false,
+      });
+
+      const result = await service.deleteTemplate('1');
+
+      expect(result.isActive).toBe(false);
+      expect(prisma.promptTemplate.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { isActive: false },
+      });
+    });
+
+    it('should throw NotFoundException when template not found', async () => {
+      prisma.promptTemplate.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteTemplate('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('rollbackTemplate', () => {
+    it('should restore text from target version and increment version', async () => {
+      const template = {
+        id: '1',
+        name: 'test',
+        templateText: 'current v3',
+        version: 3,
+      };
+      const targetHistory = {
+        id: 'h1',
+        templateId: '1',
+        version: 1,
+        templateText: 'original v1',
+        templateHash: 'hash-v1',
+      };
+      const rolledBack = {
+        ...template,
+        templateText: 'original v1',
+        version: 4,
+      };
+
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue(template);
+      prisma._tx.promptVersionHistory.findFirst.mockResolvedValue(
+        targetHistory,
+      );
+      prisma._tx.promptTemplate.update.mockResolvedValue(rolledBack);
+      prisma._tx.promptVersionHistory.create.mockResolvedValue({});
+
+      const result = await service.rollbackTemplate('1', {
+        targetVersion: 1,
+        changeNote: 'Reverting bad change',
+      });
+
+      expect(result.version).toBe(4);
+      expect(result.templateText).toBe('original v1');
+      expect(prisma._tx.promptTemplate.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { templateText: 'original v1', version: 4 },
+      });
+      expect(prisma._tx.promptVersionHistory.create).toHaveBeenCalledWith({
+        data: {
+          templateId: '1',
+          version: 4,
+          templateText: 'original v1',
+          templateHash: 'hash-v1',
+          changeNote: 'Reverting bad change',
+        },
+      });
+    });
+
+    it('should use default changeNote when not provided', async () => {
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue({
+        id: '1',
+        version: 2,
+      });
+      prisma._tx.promptVersionHistory.findFirst.mockResolvedValue({
+        templateText: 'v1 text',
+        templateHash: 'h1',
+      });
+      prisma._tx.promptTemplate.update.mockResolvedValue({
+        id: '1',
+        version: 3,
+      });
+      prisma._tx.promptVersionHistory.create.mockResolvedValue({});
+
+      await service.rollbackTemplate('1', { targetVersion: 1 });
+
+      expect(prisma._tx.promptVersionHistory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            changeNote: 'Rollback to version 1',
+          }),
+        }),
+      );
+    });
+
+    it('should throw when template not found', async () => {
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.rollbackTemplate('nonexistent', { targetVersion: 1 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw when target version not found', async () => {
+      prisma._tx.promptTemplate.findUnique.mockResolvedValue({
+        id: '1',
+        version: 3,
+      });
+      prisma._tx.promptVersionHistory.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.rollbackTemplate('1', { targetVersion: 99 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createExperiment', () => {
+    it('should reject when traffic percentages do not sum to 100', async () => {
+      const dto = {
+        name: 'test-exp',
+        templateId: 't1',
+        variants: [
+          { name: 'control', versionId: 'v1', trafficPct: 50 },
+          { name: 'variant_a', versionId: 'v2', trafficPct: 30 },
+        ],
+      };
+
+      await expect(service.createExperiment(dto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should reject when template not found', async () => {
+      prisma.promptTemplate.findUnique.mockResolvedValue(null);
+
+      const dto = {
+        name: 'test-exp',
+        templateId: 'nonexistent',
+        variants: [
+          { name: 'control', versionId: 'v1', trafficPct: 50 },
+          { name: 'variant_a', versionId: 'v2', trafficPct: 50 },
+        ],
+      };
+
+      await expect(service.createExperiment(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should create experiment with variants', async () => {
+      prisma.promptTemplate.findUnique.mockResolvedValue({ id: 't1' });
+      prisma.promptVersionHistory.findUnique
+        .mockResolvedValueOnce({ id: 'v1' })
+        .mockResolvedValueOnce({ id: 'v2' });
+
+      const created = {
+        id: 'exp-1',
+        name: 'test-exp',
+        status: 'draft',
+        variants: [
+          { name: 'control', trafficPct: 50 },
+          { name: 'variant_a', trafficPct: 50 },
+        ],
+      };
+      prisma.experiment.create.mockResolvedValue(created);
+
+      const dto = {
+        name: 'test-exp',
+        templateId: 't1',
+        variants: [
+          { name: 'control', versionId: 'v1', trafficPct: 50 },
+          { name: 'variant_a', versionId: 'v2', trafficPct: 50 },
+        ],
+      };
+
+      const result = await service.createExperiment(dto);
+
+      expect(result.status).toBe('draft');
+      expect(prisma.experiment.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('activateExperiment', () => {
+    it('should reject if experiment not in draft status', async () => {
+      prisma.experiment.findUnique.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+      });
+
+      await expect(service.activateExperiment('exp-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should reject if another experiment is active for same template', async () => {
+      prisma.experiment.findUnique.mockResolvedValue({
+        id: 'exp-2',
+        status: 'draft',
+        templateId: 't1',
+      });
+      prisma.experiment.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        name: 'existing-exp',
+        status: 'active',
+      });
+
+      await expect(service.activateExperiment('exp-2')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should activate experiment from draft', async () => {
+      prisma.experiment.findUnique.mockResolvedValue({
+        id: 'exp-1',
+        status: 'draft',
+        templateId: 't1',
+      });
+      prisma.experiment.findFirst.mockResolvedValue(null);
+      prisma.experiment.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+        variants: [],
+      });
+
+      const result = await service.activateExperiment('exp-1');
+
+      expect(result.status).toBe('active');
+    });
+  });
+
+  describe('stopExperiment', () => {
+    it('should set status to stopped with timestamp', async () => {
+      prisma.experiment.findUnique.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+      });
+      prisma.experiment.update.mockResolvedValue({
+        id: 'exp-1',
+        status: 'stopped',
+        stoppedAt: new Date(),
+        variants: [],
+      });
+
+      const result = await service.stopExperiment('exp-1');
+
+      expect(result.status).toBe('stopped');
+      expect(prisma.experiment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'stopped' }),
+        }),
+      );
+    });
+
+    it('should throw when experiment not found', async () => {
+      prisma.experiment.findUnique.mockResolvedValue(null);
+
+      await expect(service.stopExperiment('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,275 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { PrismaService } from '../common/prisma.service';
+import { CreateTemplateDto } from './dto/create-template.dto';
+import { UpdateTemplateDto } from './dto/update-template.dto';
+import { ListTemplatesQueryDto } from './dto/list-templates.dto';
+import { RollbackTemplateDto } from './dto/rollback-template.dto';
+import { CreateExperimentDto } from './dto/create-experiment.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async listTemplates(filters: ListTemplatesQueryDto) {
+    const where: Record<string, unknown> = {};
+    if (filters.category) where.category = filters.category;
+    if (filters.isActive !== undefined) where.isActive = filters.isActive;
+
+    return this.prisma.promptTemplate.findMany({
+      where,
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async getTemplateById(id: string) {
+    const template = await this.prisma.promptTemplate.findUnique({
+      where: { id },
+      include: { versionHistory: { orderBy: { version: 'desc' } } },
+    });
+
+    if (!template) {
+      throw new NotFoundException(`Template ${id} not found`);
+    }
+
+    return template;
+  }
+
+  async createTemplate(dto: CreateTemplateDto) {
+    return this.prisma.$transaction(async (tx) => {
+      const template = await tx.promptTemplate.create({
+        data: {
+          name: dto.name,
+          category: dto.category,
+          description: dto.description,
+          templateText: dto.templateText,
+          variables: dto.variables ?? [],
+        },
+      });
+
+      await tx.promptVersionHistory.create({
+        data: {
+          templateId: template.id,
+          version: template.version,
+          templateText: template.templateText,
+          templateHash: this.hash(template.templateText),
+          changeNote: dto.changeNote ?? 'Initial creation',
+        },
+      });
+
+      return template;
+    });
+  }
+
+  async updateTemplate(id: string, dto: UpdateTemplateDto) {
+    return this.prisma.$transaction(async (tx) => {
+      const existing = await tx.promptTemplate.findUnique({ where: { id } });
+      if (!existing) {
+        throw new NotFoundException(`Template ${id} not found`);
+      }
+
+      const newVersion = existing.version + 1;
+      const updateData: Record<string, unknown> = { version: newVersion };
+
+      if (dto.templateText !== undefined)
+        updateData.templateText = dto.templateText;
+      if (dto.description !== undefined)
+        updateData.description = dto.description;
+      if (dto.category !== undefined) updateData.category = dto.category;
+      if (dto.variables !== undefined) updateData.variables = dto.variables;
+
+      const updated = await tx.promptTemplate.update({
+        where: { id },
+        data: updateData,
+      });
+
+      await tx.promptVersionHistory.create({
+        data: {
+          templateId: id,
+          version: newVersion,
+          templateText: updated.templateText,
+          templateHash: this.hash(updated.templateText),
+          changeNote: dto.changeNote,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async deleteTemplate(id: string) {
+    const template = await this.prisma.promptTemplate.findUnique({
+      where: { id },
+    });
+    if (!template) {
+      throw new NotFoundException(`Template ${id} not found`);
+    }
+
+    return this.prisma.promptTemplate.update({
+      where: { id },
+      data: { isActive: false },
+    });
+  }
+
+  async rollbackTemplate(id: string, dto: RollbackTemplateDto) {
+    return this.prisma.$transaction(async (tx) => {
+      const template = await tx.promptTemplate.findUnique({ where: { id } });
+      if (!template) {
+        throw new NotFoundException(`Template ${id} not found`);
+      }
+
+      const targetHistory = await tx.promptVersionHistory.findFirst({
+        where: { templateId: id, version: dto.targetVersion },
+      });
+      if (!targetHistory) {
+        throw new NotFoundException(
+          `Version ${dto.targetVersion} not found for template ${id}`,
+        );
+      }
+
+      const newVersion = template.version + 1;
+
+      const updated = await tx.promptTemplate.update({
+        where: { id },
+        data: {
+          templateText: targetHistory.templateText,
+          version: newVersion,
+        },
+      });
+
+      await tx.promptVersionHistory.create({
+        data: {
+          templateId: id,
+          version: newVersion,
+          templateText: targetHistory.templateText,
+          templateHash: targetHistory.templateHash,
+          changeNote:
+            dto.changeNote ?? `Rollback to version ${dto.targetVersion}`,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  // --- Experiment methods ---
+
+  async createExperiment(dto: CreateExperimentDto) {
+    const totalPct = dto.variants.reduce((sum, v) => sum + v.trafficPct, 0);
+    if (totalPct !== 100) {
+      throw new BadRequestException(
+        `Variant traffic percentages must sum to 100, got ${totalPct}`,
+      );
+    }
+
+    const template = await this.prisma.promptTemplate.findUnique({
+      where: { id: dto.templateId },
+    });
+    if (!template) {
+      throw new NotFoundException(`Template ${dto.templateId} not found`);
+    }
+
+    for (const v of dto.variants) {
+      const version = await this.prisma.promptVersionHistory.findUnique({
+        where: { id: v.versionId },
+      });
+      if (!version) {
+        throw new NotFoundException(`Version entry ${v.versionId} not found`);
+      }
+    }
+
+    return this.prisma.experiment.create({
+      data: {
+        name: dto.name,
+        description: dto.description,
+        templateId: dto.templateId,
+        status: 'draft',
+        variants: {
+          create: dto.variants.map((v) => ({
+            name: v.name,
+            versionId: v.versionId,
+            trafficPct: v.trafficPct,
+          })),
+        },
+      },
+      include: { variants: true },
+    });
+  }
+
+  async listExperiments() {
+    return this.prisma.experiment.findMany({
+      include: { variants: true, template: true },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async getExperiment(id: string) {
+    const experiment = await this.prisma.experiment.findUnique({
+      where: { id },
+      include: {
+        variants: { include: { versionEntry: true } },
+        template: true,
+      },
+    });
+    if (!experiment) {
+      throw new NotFoundException(`Experiment ${id} not found`);
+    }
+    return experiment;
+  }
+
+  async activateExperiment(id: string) {
+    const experiment = await this.prisma.experiment.findUnique({
+      where: { id },
+    });
+    if (!experiment) {
+      throw new NotFoundException(`Experiment ${id} not found`);
+    }
+    if (experiment.status !== 'draft') {
+      throw new BadRequestException(
+        `Experiment is ${experiment.status}, can only activate from draft`,
+      );
+    }
+
+    const existing = await this.prisma.experiment.findFirst({
+      where: {
+        templateId: experiment.templateId,
+        status: 'active',
+        id: { not: id },
+      },
+    });
+    if (existing) {
+      throw new BadRequestException(
+        `Template already has active experiment: ${existing.name}`,
+      );
+    }
+
+    return this.prisma.experiment.update({
+      where: { id },
+      data: { status: 'active' },
+      include: { variants: true },
+    });
+  }
+
+  async stopExperiment(id: string) {
+    const experiment = await this.prisma.experiment.findUnique({
+      where: { id },
+    });
+    if (!experiment) {
+      throw new NotFoundException(`Experiment ${id} not found`);
+    }
+
+    return this.prisma.experiment.update({
+      where: { id },
+      data: { status: 'stopped', stoppedAt: new Date() },
+      include: { variants: true },
+    });
+  }
+
+  private hash(text: string): string {
+    return createHash('sha256').update(text).digest('hex');
+  }
+}

--- a/src/admin/dto/create-experiment.dto.ts
+++ b/src/admin/dto/create-experiment.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsArray,
+  IsUUID,
+  IsInt,
+  Min,
+  Max,
+  ValidateNested,
+  ArrayMinSize,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ExperimentVariantDto {
+  @ApiProperty({ description: 'Variant name (e.g., "control", "variant_a")' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: 'ID of the PromptVersionHistory entry to serve',
+  })
+  @IsString()
+  @IsUUID()
+  versionId: string;
+
+  @ApiProperty({
+    description: 'Traffic percentage (0-100)',
+    minimum: 0,
+    maximum: 100,
+  })
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  trafficPct: number;
+}
+
+export class CreateExperimentDto {
+  @ApiProperty({ description: 'Unique experiment name' })
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Experiment description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Template ID this experiment applies to' })
+  @IsString()
+  @IsUUID()
+  templateId: string;
+
+  @ApiProperty({
+    description: 'Experiment variants (traffic percentages must sum to 100)',
+    type: [ExperimentVariantDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ExperimentVariantDto)
+  @ArrayMinSize(2)
+  variants: ExperimentVariantDto[];
+}

--- a/src/admin/dto/create-template.dto.ts
+++ b/src/admin/dto/create-template.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsArray, Matches } from 'class-validator';
+
+export class CreateTemplateDto {
+  @ApiProperty({
+    description: 'Unique template name (e.g., document-analysis-petition)',
+  })
+  @IsString()
+  @Matches(/^[a-z0-9-]+$/, {
+    message: 'Name must be lowercase alphanumeric with hyphens',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'Template category',
+    enum: ['structural_analysis', 'document_analysis', 'rag'],
+  })
+  @IsString()
+  category: string;
+
+  @ApiProperty({ description: 'Human-readable description' })
+  @IsString()
+  description: string;
+
+  @ApiProperty({
+    description: 'Template text with {{VARIABLE}} placeholders',
+  })
+  @IsString()
+  templateText: string;
+
+  @ApiPropertyOptional({
+    description: 'List of expected variable names',
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  variables?: string[];
+
+  @ApiPropertyOptional({ description: 'Change note for version history' })
+  @IsOptional()
+  @IsString()
+  changeNote?: string;
+}

--- a/src/admin/dto/list-templates.dto.ts
+++ b/src/admin/dto/list-templates.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class ListTemplatesQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by category' })
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by active status' })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/src/admin/dto/rollback-template.dto.ts
+++ b/src/admin/dto/rollback-template.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class RollbackTemplateDto {
+  @ApiProperty({ description: 'Version number to rollback to', minimum: 1 })
+  @IsInt()
+  @Min(1)
+  targetVersion: number;
+
+  @ApiPropertyOptional({ description: 'Reason for rollback' })
+  @IsOptional()
+  @IsString()
+  changeNote?: string;
+}

--- a/src/admin/dto/update-template.dto.ts
+++ b/src/admin/dto/update-template.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+import { CreateTemplateDto } from './create-template.dto';
+
+export class UpdateTemplateDto extends PartialType(
+  OmitType(CreateTemplateDto, ['name'] as const),
+) {
+  @ApiProperty({ description: 'Change note (required for updates)' })
+  @IsString()
+  changeNote: string;
+}

--- a/src/admin/experiments-admin.controller.spec.ts
+++ b/src/admin/experiments-admin.controller.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ExperimentsAdminController } from './experiments-admin.controller';
+import { AdminService } from './admin.service';
+
+describe('ExperimentsAdminController', () => {
+  let controller: ExperimentsAdminController;
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExperimentsAdminController],
+      providers: [
+        {
+          provide: AdminService,
+          useValue: {
+            createExperiment: jest.fn(),
+            listExperiments: jest.fn(),
+            getExperiment: jest.fn(),
+            activateExperiment: jest.fn(),
+            stopExperiment: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('admin-test-key') },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(ExperimentsAdminController);
+    service = module.get(AdminService);
+  });
+
+  it('should call createExperiment with dto', async () => {
+    const dto = {
+      name: 'test-exp',
+      templateId: 't1',
+      variants: [
+        { name: 'control', versionId: 'v1', trafficPct: 50 },
+        { name: 'variant_a', versionId: 'v2', trafficPct: 50 },
+      ],
+    };
+    const expected = { id: 'exp-1', ...dto, status: 'draft' };
+    jest
+      .spyOn(service, 'createExperiment')
+      .mockResolvedValue(expected as never);
+
+    const result = await controller.create(dto);
+
+    expect(service.createExperiment).toHaveBeenCalledWith(dto);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call listExperiments', async () => {
+    const expected = [{ id: 'exp-1', name: 'test' }];
+    jest.spyOn(service, 'listExperiments').mockResolvedValue(expected as never);
+
+    const result = await controller.list();
+
+    expect(service.listExperiments).toHaveBeenCalled();
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getExperiment with id', async () => {
+    const expected = { id: 'exp-1', name: 'test', variants: [] };
+    jest.spyOn(service, 'getExperiment').mockResolvedValue(expected as never);
+
+    const result = await controller.getById('exp-1');
+
+    expect(service.getExperiment).toHaveBeenCalledWith('exp-1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call activateExperiment with id', async () => {
+    const expected = { id: 'exp-1', status: 'active' };
+    jest
+      .spyOn(service, 'activateExperiment')
+      .mockResolvedValue(expected as never);
+
+    const result = await controller.activate('exp-1');
+
+    expect(service.activateExperiment).toHaveBeenCalledWith('exp-1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call stopExperiment with id', async () => {
+    const expected = { id: 'exp-1', status: 'stopped' };
+    jest.spyOn(service, 'stopExperiment').mockResolvedValue(expected as never);
+
+    const result = await controller.stop('exp-1');
+
+    expect(service.stopExperiment).toHaveBeenCalledWith('exp-1');
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/admin/experiments-admin.controller.ts
+++ b/src/admin/experiments-admin.controller.ts
@@ -1,0 +1,52 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AdminKeyGuard } from '../auth/admin-key.guard';
+import { AdminService } from './admin.service';
+import { CreateExperimentDto } from './dto/create-experiment.dto';
+
+@ApiTags('admin - experiments')
+@Controller('admin/experiments')
+@UseGuards(AdminKeyGuard)
+@ApiBearerAuth()
+export class ExperimentsAdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a new A/B testing experiment' })
+  @ApiResponse({
+    status: 201,
+    description: 'Experiment created in draft status',
+  })
+  async create(@Body() dto: CreateExperimentDto) {
+    return this.adminService.createExperiment(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all experiments' })
+  async list() {
+    return this.adminService.listExperiments();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get experiment details' })
+  async getById(@Param('id') id: string) {
+    return this.adminService.getExperiment(id);
+  }
+
+  @Post(':id/activate')
+  @ApiOperation({ summary: 'Activate an experiment (start serving variants)' })
+  async activate(@Param('id') id: string) {
+    return this.adminService.activateExperiment(id);
+  }
+
+  @Post(':id/stop')
+  @ApiOperation({ summary: 'Stop an experiment' })
+  async stop(@Param('id') id: string) {
+    return this.adminService.stopExperiment(id);
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,8 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from './common/prisma.module';
 import { HealthModule } from './health/health.module';
 import { PromptsModule } from './prompts/prompts.module';
+import { AdminModule } from './admin/admin.module';
+import { ExperimentsModule } from './experiments/experiments.module';
 
 @Module({
   imports: [
@@ -12,6 +14,8 @@ import { PromptsModule } from './prompts/prompts.module';
     PrismaModule,
     HealthModule,
     PromptsModule,
+    AdminModule,
+    ExperimentsModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/admin-key.guard.spec.ts
+++ b/src/auth/admin-key.guard.spec.ts
@@ -1,0 +1,56 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AdminKeyGuard } from './admin-key.guard';
+
+function createMockContext(authHeader?: string): ExecutionContext {
+  const request: Record<string, unknown> = {
+    headers: authHeader ? { authorization: authHeader } : {},
+  };
+
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+describe('AdminKeyGuard', () => {
+  let guard: AdminKeyGuard;
+
+  beforeEach(() => {
+    const configService = {
+      get: jest.fn().mockReturnValue('admin-key-1,admin-key-2'),
+    } as unknown as ConfigService;
+    guard = new AdminKeyGuard(configService);
+  });
+
+  it('should allow a valid admin API key', () => {
+    const ctx = createMockContext('Bearer admin-key-1');
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('should reject missing Authorization header', () => {
+    const ctx = createMockContext();
+    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  });
+
+  it('should reject non-Bearer auth', () => {
+    const ctx = createMockContext('Basic abc123');
+    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  });
+
+  it('should reject invalid admin API key', () => {
+    const ctx = createMockContext('Bearer invalid-key');
+    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  });
+
+  it('should attach adminKey to request on success', () => {
+    const request: Record<string, unknown> = {
+      headers: { authorization: 'Bearer admin-key-2' },
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+
+    guard.canActivate(ctx);
+    expect(request.adminKey).toBe('admin-key-2');
+  });
+});

--- a/src/auth/admin-key.guard.ts
+++ b/src/auth/admin-key.guard.ts
@@ -1,0 +1,41 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AdminKeyGuard implements CanActivate {
+  private readonly validKeys: Set<string>;
+
+  constructor(private readonly config: ConfigService) {
+    const keys = this.config.get<string>('ADMIN_API_KEYS', '');
+    this.validKeys = new Set(
+      keys
+        .split(',')
+        .map((k) => k.trim())
+        .filter(Boolean),
+    );
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authHeader: string | undefined = request.headers['authorization'];
+
+    if (!authHeader?.startsWith('Bearer ')) {
+      throw new UnauthorizedException(
+        'Missing or invalid Authorization header',
+      );
+    }
+
+    const token = authHeader.slice(7);
+    if (!this.validKeys.has(token)) {
+      throw new UnauthorizedException('Invalid admin API key');
+    }
+
+    request.adminKey = token;
+    return true;
+  }
+}

--- a/src/experiments/experiments.module.ts
+++ b/src/experiments/experiments.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ExperimentsService } from './experiments.service';
+
+@Global()
+@Module({
+  providers: [ExperimentsService],
+  exports: [ExperimentsService],
+})
+export class ExperimentsModule {}

--- a/src/experiments/experiments.service.spec.ts
+++ b/src/experiments/experiments.service.spec.ts
@@ -1,0 +1,207 @@
+import { ExperimentsService } from './experiments.service';
+
+function createMockPrisma() {
+  return {
+    promptTemplate: {
+      findFirst: jest.fn(),
+    },
+    experiment: {
+      findFirst: jest.fn(),
+    },
+  };
+}
+
+describe('ExperimentsService', () => {
+  let service: ExperimentsService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ExperimentsService(prisma as never);
+  });
+
+  describe('resolveExperiment', () => {
+    it('should return null when template not found', async () => {
+      prisma.promptTemplate.findFirst.mockResolvedValue(null);
+
+      const result = await service.resolveExperiment('unknown', 'key-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when no active experiment', async () => {
+      prisma.promptTemplate.findFirst.mockResolvedValue({
+        id: 't1',
+        name: 'rag',
+      });
+      prisma.experiment.findFirst.mockResolvedValue(null);
+
+      const result = await service.resolveExperiment('rag', 'key-1');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return correct variant for bucketed API key', async () => {
+      prisma.promptTemplate.findFirst.mockResolvedValue({
+        id: 't1',
+        name: 'rag',
+      });
+      prisma.experiment.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+        variants: [
+          {
+            name: 'control',
+            trafficPct: 50,
+            versionEntry: {
+              templateText: 'control text',
+              version: 1,
+              templateHash: 'hash-1',
+            },
+          },
+          {
+            name: 'variant_a',
+            trafficPct: 50,
+            versionEntry: {
+              templateText: 'variant text',
+              version: 2,
+              templateHash: 'hash-2',
+            },
+          },
+        ],
+      });
+
+      const result = await service.resolveExperiment('rag', 'key-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.experimentId).toBe('exp-1');
+      expect(['control', 'variant_a']).toContain(result!.variantName);
+    });
+  });
+
+  describe('computeBucket', () => {
+    it('should be deterministic (same input = same output)', () => {
+      const bucket1 = service.computeBucket('key-1', 'exp-1');
+      const bucket2 = service.computeBucket('key-1', 'exp-1');
+
+      expect(bucket1).toBe(bucket2);
+    });
+
+    it('should produce different results for different API keys', () => {
+      const buckets = new Set<number>();
+      for (let i = 0; i < 50; i++) {
+        buckets.add(service.computeBucket(`key-${i}`, 'exp-1'));
+      }
+
+      // With 50 keys, we expect multiple distinct buckets
+      expect(buckets.size).toBeGreaterThan(5);
+    });
+
+    it('should produce values in range 0-99', () => {
+      for (let i = 0; i < 100; i++) {
+        const bucket = service.computeBucket(`key-${i}`, `exp-${i}`);
+        expect(bucket).toBeGreaterThanOrEqual(0);
+        expect(bucket).toBeLessThan(100);
+      }
+    });
+
+    it('should produce different buckets for different experiments', () => {
+      // Use multiple keys to make the test robust against individual collisions
+      let differentCount = 0;
+      for (let i = 0; i < 20; i++) {
+        const a = service.computeBucket(`key-${i}`, 'exp-a');
+        const b = service.computeBucket(`key-${i}`, 'exp-b');
+        if (a !== b) differentCount++;
+      }
+      expect(differentCount).toBeGreaterThan(10);
+    });
+  });
+
+  describe('variant selection', () => {
+    it('should correctly select variants with 50/50 split', async () => {
+      const template = { id: 't1', name: 'rag' };
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+
+      const variants = [
+        {
+          name: 'control',
+          trafficPct: 50,
+          versionEntry: {
+            templateText: 'control',
+            version: 1,
+            templateHash: 'h1',
+          },
+        },
+        {
+          name: 'variant_a',
+          trafficPct: 50,
+          versionEntry: {
+            templateText: 'variant',
+            version: 2,
+            templateHash: 'h2',
+          },
+        },
+      ];
+
+      prisma.experiment.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+        variants,
+      });
+
+      // Test with many keys and verify both variants are served
+      const served = new Set<string>();
+      for (let i = 0; i < 100; i++) {
+        const result = await service.resolveExperiment('rag', `key-${i}`);
+        if (result) served.add(result.variantName);
+      }
+
+      expect(served.has('control')).toBe(true);
+      expect(served.has('variant_a')).toBe(true);
+    });
+
+    it('should correctly select variants with 90/10 split', async () => {
+      const template = { id: 't1', name: 'rag' };
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+
+      const variants = [
+        {
+          name: 'control',
+          trafficPct: 90,
+          versionEntry: {
+            templateText: 'control',
+            version: 1,
+            templateHash: 'h1',
+          },
+        },
+        {
+          name: 'variant_a',
+          trafficPct: 10,
+          versionEntry: {
+            templateText: 'variant',
+            version: 2,
+            templateHash: 'h2',
+          },
+        },
+      ];
+
+      prisma.experiment.findFirst.mockResolvedValue({
+        id: 'exp-1',
+        status: 'active',
+        variants,
+      });
+
+      let controlCount = 0;
+      let variantCount = 0;
+      for (let i = 0; i < 200; i++) {
+        const result = await service.resolveExperiment('rag', `key-${i}`);
+        if (result?.variantName === 'control') controlCount++;
+        if (result?.variantName === 'variant_a') variantCount++;
+      }
+
+      // Control should get ~90% of traffic
+      expect(controlCount).toBeGreaterThan(variantCount);
+      expect(variantCount).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/experiments/experiments.service.ts
+++ b/src/experiments/experiments.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { PrismaService } from '../common/prisma.service';
+
+export interface ExperimentResult {
+  templateText: string;
+  version: number;
+  templateHash: string;
+  experimentId: string;
+  variantName: string;
+}
+
+interface VariantWithVersion {
+  name: string;
+  trafficPct: number;
+  versionEntry: {
+    templateText: string;
+    version: number;
+    templateHash: string;
+  };
+}
+
+@Injectable()
+export class ExperimentsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async resolveExperiment(
+    templateName: string,
+    apiKey: string,
+  ): Promise<ExperimentResult | null> {
+    const template = await this.prisma.promptTemplate.findFirst({
+      where: { name: templateName, isActive: true },
+    });
+    if (!template) return null;
+
+    const experiment = await this.prisma.experiment.findFirst({
+      where: { templateId: template.id, status: 'active' },
+      include: {
+        variants: {
+          include: { versionEntry: true },
+          orderBy: { trafficPct: 'desc' },
+        },
+      },
+    });
+
+    if (!experiment || experiment.variants.length === 0) return null;
+
+    const variant = this.bucketToVariant(
+      apiKey,
+      experiment.id,
+      experiment.variants,
+    );
+
+    return {
+      templateText: variant.versionEntry.templateText,
+      version: variant.versionEntry.version,
+      templateHash: variant.versionEntry.templateHash,
+      experimentId: experiment.id,
+      variantName: variant.name,
+    };
+  }
+
+  private bucketToVariant(
+    apiKey: string,
+    experimentId: string,
+    variants: VariantWithVersion[],
+  ): VariantWithVersion {
+    const bucket = this.computeBucket(apiKey, experimentId);
+    let cumulative = 0;
+    for (const variant of variants) {
+      cumulative += variant.trafficPct;
+      if (bucket < cumulative) {
+        return variant;
+      }
+    }
+    return variants[variants.length - 1];
+  }
+
+  computeBucket(apiKey: string, experimentId: string): number {
+    const hash = createHash('sha256')
+      .update(apiKey + ':' + experimentId)
+      .digest('hex');
+    const num = parseInt(hash.slice(0, 8), 16);
+    return num % 100;
+  }
+}

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -41,6 +41,7 @@ describe('PromptsController', () => {
       promptText: 'rendered',
       promptHash: 'abc',
       promptVersion: 'v1',
+      expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
     };
 
     jest
@@ -64,6 +65,7 @@ describe('PromptsController', () => {
       promptText: 'rendered',
       promptHash: 'abc',
       promptVersion: 'v1',
+      expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
     };
 
     jest
@@ -82,6 +84,7 @@ describe('PromptsController', () => {
       promptText: 'rendered',
       promptHash: 'abc',
       promptVersion: 'v1',
+      expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
     };
 
     jest.spyOn(service, 'getRagPrompt').mockResolvedValue(expected);

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -15,13 +15,37 @@ function createMockPrisma() {
   };
 }
 
+function createMockConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    get: jest.fn((key: string, defaultValue?: unknown) => {
+      if (key in overrides) return overrides[key];
+      if (key === 'PROMPT_TTL_SECONDS') return 3600;
+      return defaultValue;
+    }),
+  };
+}
+
+function createMockExperiments() {
+  return {
+    resolveExperiment: jest.fn().mockResolvedValue(null),
+  };
+}
+
 describe('PromptsService', () => {
   let service: PromptsService;
   let prisma: ReturnType<typeof createMockPrisma>;
+  let config: ReturnType<typeof createMockConfig>;
+  let experiments: ReturnType<typeof createMockExperiments>;
 
   beforeEach(() => {
     prisma = createMockPrisma();
-    service = new PromptsService(prisma as never);
+    config = createMockConfig();
+    experiments = createMockExperiments();
+    service = new PromptsService(
+      prisma as never,
+      config as never,
+      experiments as never,
+    );
   });
 
   describe('getStructuralAnalysisPrompt', () => {
@@ -43,7 +67,7 @@ describe('PromptsService', () => {
       };
 
       prisma.promptTemplate.findFirst
-        .mockResolvedValueOnce(baseTemplate) // structural-analysis
+        .mockResolvedValueOnce(baseTemplate) // structural-analysis (from resolveTemplate fallback)
         .mockResolvedValueOnce(schemaTemplate); // structural-schema-propositions
       prisma.promptRequestLog.create.mockResolvedValue({});
 
@@ -62,6 +86,8 @@ describe('PromptsService', () => {
       expect(result.promptText).toContain('<div>test</div>');
       expect(result.promptHash).toBeDefined();
       expect(result.promptVersion).toBe('v1');
+      expect(result.expiresAt).toBeDefined();
+      expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
     });
 
     it('should include hints when provided', async () => {
@@ -164,6 +190,7 @@ describe('PromptsService', () => {
       expect(result.promptText).toContain('We the people...');
       expect(result.promptText).toContain('Respond with valid JSON only.');
       expect(result.promptVersion).toBe('v1');
+      expect(result.expiresAt).toBeDefined();
     });
 
     it('should fall back to generic when specific type not found', async () => {
@@ -231,6 +258,7 @@ describe('PromptsService', () => {
       expect(result.promptText).toContain('The sky is blue.');
       expect(result.promptText).toContain('What color is the sky?');
       expect(result.promptVersion).toBe('v3');
+      expect(result.expiresAt).toBeDefined();
     });
   });
 
@@ -260,8 +288,141 @@ describe('PromptsService', () => {
     });
   });
 
-  describe('request logging', () => {
-    it('should log prompt requests', async () => {
+  describe('TTL / expiresAt', () => {
+    it('should set expiresAt based on PROMPT_TTL_SECONDS config', async () => {
+      const customConfig = createMockConfig({ PROMPT_TTL_SECONDS: 7200 });
+      const customService = new PromptsService(
+        prisma as never,
+        customConfig as never,
+        experiments as never,
+      );
+
+      const template = {
+        id: '1',
+        name: 'rag',
+        templateText: '{{CONTEXT}} {{QUERY}}',
+        version: 1,
+        isActive: true,
+      };
+
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const before = Date.now();
+      const result = await customService.getRagPrompt(
+        { context: 'ctx', query: 'q' },
+        'test-key',
+      );
+      const after = Date.now();
+
+      const expiresMs = new Date(result.expiresAt).getTime();
+      // Should expire ~7200 seconds from now
+      expect(expiresMs).toBeGreaterThanOrEqual(before + 7200 * 1000);
+      expect(expiresMs).toBeLessThanOrEqual(after + 7200 * 1000);
+    });
+
+    it('should default to 3600 seconds TTL', async () => {
+      const defaultConfig = createMockConfig();
+      const defaultService = new PromptsService(
+        prisma as never,
+        defaultConfig as never,
+        experiments as never,
+      );
+
+      const template = {
+        id: '1',
+        name: 'rag',
+        templateText: '{{CONTEXT}} {{QUERY}}',
+        version: 1,
+        isActive: true,
+      };
+
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const before = Date.now();
+      const result = await defaultService.getRagPrompt(
+        { context: 'ctx', query: 'q' },
+        'test-key',
+      );
+
+      const expiresMs = new Date(result.expiresAt).getTime();
+      expect(expiresMs).toBeGreaterThanOrEqual(before + 3600 * 1000);
+    });
+  });
+
+  describe('A/B testing integration', () => {
+    it('should serve experiment variant when active experiment exists', async () => {
+      experiments.resolveExperiment.mockResolvedValue({
+        templateText: 'Experiment version: {{CONTEXT}} {{QUERY}}',
+        version: 2,
+        templateHash: 'exp-hash',
+        experimentId: 'exp-1',
+        variantName: 'variant_a',
+      });
+
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const result = await service.getRagPrompt(
+        { context: 'ctx', query: 'q' },
+        'test-key',
+      );
+
+      expect(result.promptText).toContain('Experiment version: ctx q');
+      expect(result.promptVersion).toBe('v2');
+    });
+
+    it('should fall back to default when no active experiment', async () => {
+      experiments.resolveExperiment.mockResolvedValue(null);
+
+      const template = {
+        id: '1',
+        name: 'rag',
+        templateText: 'Default: {{CONTEXT}} {{QUERY}}',
+        version: 1,
+        isActive: true,
+      };
+
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const result = await service.getRagPrompt(
+        { context: 'ctx', query: 'q' },
+        'test-key',
+      );
+
+      expect(result.promptText).toContain('Default: ctx q');
+      expect(result.promptVersion).toBe('v1');
+    });
+
+    it('should log experimentId and variantName when experiment is active', async () => {
+      experiments.resolveExperiment.mockResolvedValue({
+        templateText: '{{CONTEXT}} {{QUERY}}',
+        version: 2,
+        templateHash: 'hash',
+        experimentId: 'exp-1',
+        variantName: 'control',
+      });
+
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      await service.getRagPrompt(
+        { context: 'ctx', query: 'q' },
+        'my-secret-key-123',
+      );
+
+      expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
+        data: {
+          endpoint: 'rag',
+          promptVersion: 2,
+          apiKeyPrefix: 'my-secre...',
+          experimentId: 'exp-1',
+          variantName: 'control',
+        },
+      });
+    });
+
+    it('should log null experiment fields when no experiment is active', async () => {
       const template = {
         id: '1',
         name: 'rag',
@@ -283,6 +444,8 @@ describe('PromptsService', () => {
           endpoint: 'rag',
           promptVersion: 1,
           apiKeyPrefix: 'my-secre...',
+          experimentId: null,
+          variantName: null,
         },
       });
     });

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../common/prisma.service';
+import { ExperimentsService } from '../experiments/experiments.service';
 import { StructuralAnalysisDto } from './dto/structural-analysis.dto';
 import { DocumentAnalysisDto } from './dto/document-analysis.dto';
 import { RagDto } from './dto/rag.dto';
@@ -9,6 +11,7 @@ export interface PromptServiceResponse {
   promptText: string;
   promptHash: string;
   promptVersion: string;
+  expiresAt: string;
 }
 
 export interface VerifyResult {
@@ -16,18 +19,31 @@ export interface VerifyResult {
   templateName?: string;
 }
 
+interface ResolvedTemplate {
+  templateText: string;
+  version: number;
+  name: string;
+  experimentId?: string;
+  variantName?: string;
+}
+
 @Injectable()
 export class PromptsService {
   private readonly logger = new Logger(PromptsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly config: ConfigService,
+    private readonly experiments: ExperimentsService,
+  ) {}
 
   async getStructuralAnalysisPrompt(
     dto: StructuralAnalysisDto,
     apiKey: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.getActiveTemplate('structural-analysis');
+    const template = await this.resolveTemplate('structural-analysis', apiKey);
 
+    // Schema/auxiliary templates always use default (no A/B)
     const schemaTemplate = await this.getActiveTemplate(
       `structural-schema-${dto.dataType}`,
       'structural-schema-default',
@@ -51,7 +67,13 @@ export class PromptsService {
     const response = this.buildResponse(template);
     response.promptText = promptText;
 
-    await this.logRequest('structural-analysis', template.version, apiKey);
+    await this.logRequest(
+      'structural-analysis',
+      template.version,
+      apiKey,
+      template.experimentId,
+      template.variantName,
+    );
 
     return response;
   }
@@ -60,11 +82,13 @@ export class PromptsService {
     dto: DocumentAnalysisDto,
     apiKey: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.getActiveTemplate(
+    const template = await this.resolveTemplate(
       `document-analysis-${dto.documentType}`,
+      apiKey,
       'document-analysis-generic',
     );
 
+    // Base instructions always use default (no A/B)
     const baseInstructions = await this.getActiveTemplate(
       'document-analysis-base-instructions',
     );
@@ -77,7 +101,13 @@ export class PromptsService {
     const response = this.buildResponse(template);
     response.promptText = promptText;
 
-    await this.logRequest('document-analysis', template.version, apiKey);
+    await this.logRequest(
+      'document-analysis',
+      template.version,
+      apiKey,
+      template.experimentId,
+      template.variantName,
+    );
 
     return response;
   }
@@ -86,7 +116,7 @@ export class PromptsService {
     dto: RagDto,
     apiKey: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.getActiveTemplate('rag');
+    const template = await this.resolveTemplate('rag', apiKey);
 
     const promptText = this.interpolate(template.templateText, {
       CONTEXT: dto.context,
@@ -96,7 +126,13 @@ export class PromptsService {
     const response = this.buildResponse(template);
     response.promptText = promptText;
 
-    await this.logRequest('rag', template.version, apiKey);
+    await this.logRequest(
+      'rag',
+      template.version,
+      apiKey,
+      template.experimentId,
+      template.variantName,
+    );
 
     return response;
   }
@@ -120,10 +156,34 @@ export class PromptsService {
     return { valid: false };
   }
 
+  private async resolveTemplate(
+    name: string,
+    apiKey: string,
+    fallbackName?: string,
+  ): Promise<ResolvedTemplate> {
+    // Check for active A/B experiment first
+    const experimentResult = await this.experiments.resolveExperiment(
+      name,
+      apiKey,
+    );
+    if (experimentResult) {
+      return {
+        templateText: experimentResult.templateText,
+        version: experimentResult.version,
+        name,
+        experimentId: experimentResult.experimentId,
+        variantName: experimentResult.variantName,
+      };
+    }
+
+    // Fall back to default active template
+    return this.getActiveTemplate(name, fallbackName);
+  }
+
   private async getActiveTemplate(
     name: string,
     fallbackName?: string,
-  ): Promise<{ templateText: string; version: number; name: string }> {
+  ): Promise<ResolvedTemplate> {
     let template = await this.prisma.promptTemplate.findFirst({
       where: { name, isActive: true },
     });
@@ -160,10 +220,14 @@ export class PromptsService {
     templateText: string;
     version: number;
   }): PromptServiceResponse {
+    const ttlSeconds = this.config.get<number>('PROMPT_TTL_SECONDS', 3600);
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
+
     return {
       promptText: '',
       promptHash: this.hash(template.templateText),
       promptVersion: `v${template.version}`,
+      expiresAt,
     };
   }
 
@@ -171,6 +235,8 @@ export class PromptsService {
     endpoint: string,
     version: number,
     apiKey: string,
+    experimentId?: string,
+    variantName?: string,
   ): Promise<void> {
     try {
       await this.prisma.promptRequestLog.create({
@@ -178,6 +244,8 @@ export class PromptsService {
           endpoint,
           promptVersion: version,
           apiKeyPrefix: apiKey.slice(0, 8) + '...',
+          experimentId: experimentId ?? null,
+          variantName: variantName ?? null,
         },
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

- **Admin CRUD API** with separate admin key authentication (`AdminKeyGuard`) for template create, update, soft-delete, and rollback with full version history
- **A/B testing framework** with deterministic SHA-256 bucketing engine, experiment lifecycle (draft → active → stopped), and per-template variant serving integrated into prompt resolution
- **Prompt TTL/expiry** via configurable `PROMPT_TTL_SECONDS` — all prompt responses now include an `expiresAt` field so nodes know when to re-fetch

Completes Issues #417 and #418.

## Changes

- 17 new files, 12 modified files (29 total, +2322 lines)
- 74 passing tests across 9 test suites
- Prisma schema migration adds `Experiment` and `ExperimentVariant` models
- Updated docs: API reference, architecture, security model, README

## Test plan

- [x] `pnpm test` — 74 tests pass (9 suites)
- [x] `pnpm lint` — no errors
- [x] `pnpm build` — compiles cleanly
- [ ] `docker compose up` — verify service starts and DB migrates
- [ ] Verify existing prompt endpoints still work with node API keys (backward compatible)
- [ ] Verify `expiresAt` present in all prompt responses
- [ ] Verify admin endpoints reject node keys, accept admin keys
- [ ] Template lifecycle: create → update → list → rollback → soft delete
- [ ] Experiment lifecycle: create → activate → verify consistent bucketing → stop → verify default resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)