### PR TITLE
Release: admin CRUD, integration tests, per-region tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Database
 DATABASE_URL="postgresql://postgres:postgres@localhost:5433/prompt_service?schema=public"
 
-# API Keys (comma-separated list of valid keys for node access)
-API_KEYS="dev-key-1,dev-key-2"
+# API Keys (comma-separated, format: region:key — each region gets its own key for usage tracking)
+API_KEYS="us-west:dev-key-1,us-east:dev-key-2"
 
 # Admin API Keys (comma-separated, separate from node API keys)
 ADMIN_API_KEYS="admin-dev-key-1"

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5433/prompt_service?schema=public"
 
 # API Keys (comma-separated, format: region:key — each region gets its own key for usage tracking)
-API_KEYS="us-west:dev-key-1,us-east:dev-key-2"
+API_KEYS="ca:dev-key-1,tx:dev-key-2"
 
 # Admin API Keys (comma-separated, separate from node API keys)
 ADMIN_API_KEYS="admin-dev-key-1"

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -19,7 +19,7 @@ services:
       - '3101:3100'
     environment:
       DATABASE_URL: postgresql://postgres:postgres@prompt-db-test:5432/prompt_service_test?schema=public
-      API_KEYS: us-east:test-api-key-1,us-west:test-api-key-2
+      API_KEYS: ca:test-api-key-1,tx:test-api-key-2
       ADMIN_API_KEYS: admin-test-key-1
       PROMPT_TTL_SECONDS: 300
       PORT: 3100

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -19,7 +19,7 @@ services:
       - '3101:3100'
     environment:
       DATABASE_URL: postgresql://postgres:postgres@prompt-db-test:5432/prompt_service_test?schema=public
-      API_KEYS: test-api-key-1,test-api-key-2
+      API_KEYS: us-east:test-api-key-1,us-west:test-api-key-2
       ADMIN_API_KEYS: admin-test-key-1
       PROMPT_TTL_SECONDS: 300
       PORT: 3100

--- a/prisma/migrations/20260227040000_add_region_to_logs/migration.sql
+++ b/prisma/migrations/20260227040000_add_region_to_logs/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "prompt_request_logs" ADD COLUMN "region" TEXT NOT NULL DEFAULT 'unknown';
+
+-- CreateIndex
+CREATE INDEX "prompt_request_logs_region_idx" ON "prompt_request_logs"("region");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,12 +49,14 @@ model PromptRequestLog {
   endpoint      String
   promptVersion Int      @map("prompt_version")
   apiKeyPrefix  String   @map("api_key_prefix")
+  region        String   @default("unknown")
   experimentId  String?  @map("experiment_id")
   variantName   String?  @map("variant_name")
   createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
 
   @@index([endpoint])
   @@index([apiKeyPrefix])
+  @@index([region])
   @@index([createdAt])
   @@map("prompt_request_logs")
 }

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -17,7 +17,9 @@ describe('ApiKeyGuard', () => {
 
   beforeEach(() => {
     const configService = {
-      get: jest.fn().mockReturnValue('key-1,key-2,key-3'),
+      get: jest
+        .fn()
+        .mockReturnValue('us-east:key-1,us-west:key-2,eu-west:key-3'),
     } as unknown as ConfigService;
     guard = new ApiKeyGuard(configService);
   });
@@ -42,7 +44,7 @@ describe('ApiKeyGuard', () => {
     expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
   });
 
-  it('should attach apiKey to request on success', () => {
+  it('should attach apiKey and region to request on success', () => {
     const request: Record<string, unknown> = {
       headers: { authorization: 'Bearer key-2' },
     };
@@ -52,5 +54,24 @@ describe('ApiKeyGuard', () => {
 
     guard.canActivate(ctx);
     expect(request.apiKey).toBe('key-2');
+    expect(request.region).toBe('us-west');
+  });
+
+  it('should default to unknown region when no colon in key entry', () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('legacy-key'),
+    } as unknown as ConfigService;
+    const legacyGuard = new ApiKeyGuard(configService);
+
+    const request: Record<string, unknown> = {
+      headers: { authorization: 'Bearer legacy-key' },
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+
+    legacyGuard.canActivate(ctx);
+    expect(request.apiKey).toBe('legacy-key');
+    expect(request.region).toBe('unknown');
   });
 });

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -17,9 +17,7 @@ describe('ApiKeyGuard', () => {
 
   beforeEach(() => {
     const configService = {
-      get: jest
-        .fn()
-        .mockReturnValue('us-east:key-1,us-west:key-2,eu-west:key-3'),
+      get: jest.fn().mockReturnValue('ca:key-1,tx:key-2,ny:key-3'),
     } as unknown as ConfigService;
     guard = new ApiKeyGuard(configService);
   });
@@ -54,7 +52,7 @@ describe('ApiKeyGuard', () => {
 
     guard.canActivate(ctx);
     expect(request.apiKey).toBe('key-2');
-    expect(request.region).toBe('us-west');
+    expect(request.region).toBe('tx');
   });
 
   it('should default to unknown region when no colon in key entry', () => {

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -8,15 +8,23 @@ import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-  private readonly validKeys: Set<string>;
+  private readonly keyToRegion: Map<string, string>;
 
   constructor(private readonly config: ConfigService) {
     const keys = this.config.get<string>('API_KEYS', '');
-    this.validKeys = new Set(
+    this.keyToRegion = new Map(
       keys
         .split(',')
-        .map((k) => k.trim())
-        .filter(Boolean),
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .map((entry) => {
+          const colonIdx = entry.indexOf(':');
+          if (colonIdx === -1) return [entry, 'unknown'] as [string, string];
+          return [entry.slice(colonIdx + 1), entry.slice(0, colonIdx)] as [
+            string,
+            string,
+          ];
+        }),
     );
   }
 
@@ -31,12 +39,14 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     const token = authHeader.slice(7);
-    if (!this.validKeys.has(token)) {
+    const region = this.keyToRegion.get(token);
+    if (region === undefined) {
       throw new UnauthorizedException('Invalid API key');
     }
 
-    // Attach the API key identifier for analytics/logging
+    // Attach the API key and region for analytics/logging
     request.apiKey = token;
+    request.region = region;
     return true;
   }
 }

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -50,11 +50,13 @@ describe('PromptsController', () => {
 
     const result = await controller.structuralAnalysis(dto, {
       apiKey: 'key',
+      region: 'us-east',
     });
 
     expect(service.getStructuralAnalysisPrompt).toHaveBeenCalledWith(
       dto,
       'key',
+      'us-east',
     );
     expect(result).toEqual(expected);
   });
@@ -72,9 +74,16 @@ describe('PromptsController', () => {
       .spyOn(service, 'getDocumentAnalysisPrompt')
       .mockResolvedValue(expected);
 
-    const result = await controller.documentAnalysis(dto, { apiKey: 'key' });
+    const result = await controller.documentAnalysis(dto, {
+      apiKey: 'key',
+      region: 'us-east',
+    });
 
-    expect(service.getDocumentAnalysisPrompt).toHaveBeenCalledWith(dto, 'key');
+    expect(service.getDocumentAnalysisPrompt).toHaveBeenCalledWith(
+      dto,
+      'key',
+      'us-east',
+    );
     expect(result).toEqual(expected);
   });
 
@@ -89,9 +98,12 @@ describe('PromptsController', () => {
 
     jest.spyOn(service, 'getRagPrompt').mockResolvedValue(expected);
 
-    const result = await controller.rag(dto, { apiKey: 'key' });
+    const result = await controller.rag(dto, {
+      apiKey: 'key',
+      region: 'us-east',
+    });
 
-    expect(service.getRagPrompt).toHaveBeenCalledWith(dto, 'key');
+    expect(service.getRagPrompt).toHaveBeenCalledWith(dto, 'key', 'us-east');
     expect(result).toEqual(expected);
   });
 

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -50,13 +50,13 @@ describe('PromptsController', () => {
 
     const result = await controller.structuralAnalysis(dto, {
       apiKey: 'key',
-      region: 'us-east',
+      region: 'ca',
     });
 
     expect(service.getStructuralAnalysisPrompt).toHaveBeenCalledWith(
       dto,
       'key',
-      'us-east',
+      'ca',
     );
     expect(result).toEqual(expected);
   });
@@ -76,13 +76,13 @@ describe('PromptsController', () => {
 
     const result = await controller.documentAnalysis(dto, {
       apiKey: 'key',
-      region: 'us-east',
+      region: 'ca',
     });
 
     expect(service.getDocumentAnalysisPrompt).toHaveBeenCalledWith(
       dto,
       'key',
-      'us-east',
+      'ca',
     );
     expect(result).toEqual(expected);
   });
@@ -100,10 +100,10 @@ describe('PromptsController', () => {
 
     const result = await controller.rag(dto, {
       apiKey: 'key',
-      region: 'us-east',
+      region: 'ca',
     });
 
-    expect(service.getRagPrompt).toHaveBeenCalledWith(dto, 'key', 'us-east');
+    expect(service.getRagPrompt).toHaveBeenCalledWith(dto, 'key', 'ca');
     expect(result).toEqual(expected);
   });
 

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -32,9 +32,13 @@ export class PromptsController {
   @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   async structuralAnalysis(
     @Body() dto: StructuralAnalysisDto,
-    @Req() req: { apiKey: string },
+    @Req() req: { apiKey: string; region: string },
   ) {
-    return this.promptsService.getStructuralAnalysisPrompt(dto, req.apiKey);
+    return this.promptsService.getStructuralAnalysisPrompt(
+      dto,
+      req.apiKey,
+      req.region,
+    );
   }
 
   @Post('document-analysis')
@@ -51,9 +55,13 @@ export class PromptsController {
   @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
   async documentAnalysis(
     @Body() dto: DocumentAnalysisDto,
-    @Req() req: { apiKey: string },
+    @Req() req: { apiKey: string; region: string },
   ) {
-    return this.promptsService.getDocumentAnalysisPrompt(dto, req.apiKey);
+    return this.promptsService.getDocumentAnalysisPrompt(
+      dto,
+      req.apiKey,
+      req.region,
+    );
   }
 
   @Post('rag')
@@ -68,8 +76,11 @@ export class PromptsController {
   @ApiResponse({ status: 401, description: 'Invalid API key' })
   @ApiResponse({ status: 404, description: 'Template not found' })
   @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
-  async rag(@Body() dto: RagDto, @Req() req: { apiKey: string }) {
-    return this.promptsService.getRagPrompt(dto, req.apiKey);
+  async rag(
+    @Body() dto: RagDto,
+    @Req() req: { apiKey: string; region: string },
+  ) {
+    return this.promptsService.getRagPrompt(dto, req.apiKey, req.region);
   }
 
   @Post('verify')

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -78,6 +78,7 @@ describe('PromptsService', () => {
           html: '<div>test</div>',
         },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('propositions');
@@ -119,6 +120,7 @@ describe('PromptsService', () => {
           html: '<table></table>',
         },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('Use table rows');
@@ -154,6 +156,7 @@ describe('PromptsService', () => {
           html: '<div></div>',
         },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('Extract all fields');
@@ -185,6 +188,7 @@ describe('PromptsService', () => {
       const result = await service.getDocumentAnalysisPrompt(
         { documentType: 'petition', text: 'We the people...' },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('We the people...');
@@ -218,6 +222,7 @@ describe('PromptsService', () => {
       const result = await service.getDocumentAnalysisPrompt(
         { documentType: 'unknown', text: 'Some text' },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('Generic: Some text');
@@ -232,6 +237,7 @@ describe('PromptsService', () => {
         service.getDocumentAnalysisPrompt(
           { documentType: 'nonexistent', text: 'text' },
           'test-key',
+          'us-east',
         ),
       ).rejects.toThrow(NotFoundException);
     });
@@ -253,6 +259,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'The sky is blue.', query: 'What color is the sky?' },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('The sky is blue.');
@@ -312,6 +319,7 @@ describe('PromptsService', () => {
       const result = await customService.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
+        'us-east',
       );
       const after = Date.now();
 
@@ -344,6 +352,7 @@ describe('PromptsService', () => {
       const result = await defaultService.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
+        'us-east',
       );
 
       const expiresMs = new Date(result.expiresAt).getTime();
@@ -366,6 +375,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('Experiment version: ctx q');
@@ -389,6 +399,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
+        'us-east',
       );
 
       expect(result.promptText).toContain('Default: ctx q');
@@ -409,6 +420,7 @@ describe('PromptsService', () => {
       await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'my-secret-key-123',
+        'us-west',
       );
 
       expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
@@ -416,6 +428,7 @@ describe('PromptsService', () => {
           endpoint: 'rag',
           promptVersion: 2,
           apiKeyPrefix: 'my-secre...',
+          region: 'us-west',
           experimentId: 'exp-1',
           variantName: 'control',
         },
@@ -437,6 +450,7 @@ describe('PromptsService', () => {
       await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'my-secret-key-123',
+        'us-west',
       );
 
       expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
@@ -444,6 +458,7 @@ describe('PromptsService', () => {
           endpoint: 'rag',
           promptVersion: 1,
           apiKeyPrefix: 'my-secre...',
+          region: 'us-west',
           experimentId: null,
           variantName: null,
         },

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -78,7 +78,7 @@ describe('PromptsService', () => {
           html: '<div>test</div>',
         },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('propositions');
@@ -120,7 +120,7 @@ describe('PromptsService', () => {
           html: '<table></table>',
         },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('Use table rows');
@@ -156,7 +156,7 @@ describe('PromptsService', () => {
           html: '<div></div>',
         },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('Extract all fields');
@@ -188,7 +188,7 @@ describe('PromptsService', () => {
       const result = await service.getDocumentAnalysisPrompt(
         { documentType: 'petition', text: 'We the people...' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('We the people...');
@@ -222,7 +222,7 @@ describe('PromptsService', () => {
       const result = await service.getDocumentAnalysisPrompt(
         { documentType: 'unknown', text: 'Some text' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('Generic: Some text');
@@ -237,7 +237,7 @@ describe('PromptsService', () => {
         service.getDocumentAnalysisPrompt(
           { documentType: 'nonexistent', text: 'text' },
           'test-key',
-          'us-east',
+          'ca',
         ),
       ).rejects.toThrow(NotFoundException);
     });
@@ -259,7 +259,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'The sky is blue.', query: 'What color is the sky?' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('The sky is blue.');
@@ -319,7 +319,7 @@ describe('PromptsService', () => {
       const result = await customService.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
-        'us-east',
+        'ca',
       );
       const after = Date.now();
 
@@ -352,7 +352,7 @@ describe('PromptsService', () => {
       const result = await defaultService.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       const expiresMs = new Date(result.expiresAt).getTime();
@@ -375,7 +375,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('Experiment version: ctx q');
@@ -399,7 +399,7 @@ describe('PromptsService', () => {
       const result = await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'test-key',
-        'us-east',
+        'ca',
       );
 
       expect(result.promptText).toContain('Default: ctx q');
@@ -420,7 +420,7 @@ describe('PromptsService', () => {
       await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'my-secret-key-123',
-        'us-west',
+        'tx',
       );
 
       expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
@@ -428,7 +428,7 @@ describe('PromptsService', () => {
           endpoint: 'rag',
           promptVersion: 2,
           apiKeyPrefix: 'my-secre...',
-          region: 'us-west',
+          region: 'tx',
           experimentId: 'exp-1',
           variantName: 'control',
         },
@@ -450,7 +450,7 @@ describe('PromptsService', () => {
       await service.getRagPrompt(
         { context: 'ctx', query: 'q' },
         'my-secret-key-123',
-        'us-west',
+        'tx',
       );
 
       expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
@@ -458,7 +458,7 @@ describe('PromptsService', () => {
           endpoint: 'rag',
           promptVersion: 1,
           apiKeyPrefix: 'my-secre...',
-          region: 'us-west',
+          region: 'tx',
           experimentId: null,
           variantName: null,
         },

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -40,6 +40,7 @@ export class PromptsService {
   async getStructuralAnalysisPrompt(
     dto: StructuralAnalysisDto,
     apiKey: string,
+    region: string,
   ): Promise<PromptServiceResponse> {
     const template = await this.resolveTemplate('structural-analysis', apiKey);
 
@@ -71,6 +72,7 @@ export class PromptsService {
       'structural-analysis',
       template.version,
       apiKey,
+      region,
       template.experimentId,
       template.variantName,
     );
@@ -81,6 +83,7 @@ export class PromptsService {
   async getDocumentAnalysisPrompt(
     dto: DocumentAnalysisDto,
     apiKey: string,
+    region: string,
   ): Promise<PromptServiceResponse> {
     const template = await this.resolveTemplate(
       `document-analysis-${dto.documentType}`,
@@ -105,6 +108,7 @@ export class PromptsService {
       'document-analysis',
       template.version,
       apiKey,
+      region,
       template.experimentId,
       template.variantName,
     );
@@ -115,6 +119,7 @@ export class PromptsService {
   async getRagPrompt(
     dto: RagDto,
     apiKey: string,
+    region: string,
   ): Promise<PromptServiceResponse> {
     const template = await this.resolveTemplate('rag', apiKey);
 
@@ -130,6 +135,7 @@ export class PromptsService {
       'rag',
       template.version,
       apiKey,
+      region,
       template.experimentId,
       template.variantName,
     );
@@ -235,6 +241,7 @@ export class PromptsService {
     endpoint: string,
     version: number,
     apiKey: string,
+    region: string,
     experimentId?: string,
     variantName?: string,
   ): Promise<void> {
@@ -244,6 +251,7 @@ export class PromptsService {
           endpoint,
           promptVersion: version,
           apiKeyPrefix: apiKey.slice(0, 8) + '...',
+          region,
           experimentId: experimentId ?? null,
           variantName: variantName ?? null,
         },

--- a/test/integration/prompts/document-analysis.integration.spec.ts
+++ b/test/integration/prompts/document-analysis.integration.spec.ts
@@ -1,6 +1,6 @@
 import { apiPost } from '../utils';
 import { getDb } from '../utils/db-helpers';
-import { API_KEY } from '../utils/config';
+import { API_KEY, API_KEY_REGION } from '../utils/config';
 
 describe('Document Analysis Prompt (integration)', () => {
   it('should render petition prompt with civic analyst instruction', async () => {
@@ -73,5 +73,6 @@ describe('Document Analysis Prompt (integration)', () => {
 
     expect(logs.length).toBeGreaterThanOrEqual(1);
     expect(logs[0].apiKeyPrefix).toBe(API_KEY.slice(0, 8) + '...');
+    expect(logs[0].region).toBe(API_KEY_REGION);
   });
 });

--- a/test/integration/utils/config.ts
+++ b/test/integration/utils/config.ts
@@ -2,7 +2,9 @@ export const BASE_URL =
   process.env.PROMPT_SERVICE_URL || 'http://localhost:3101';
 
 export const API_KEY = process.env.API_KEY || 'test-api-key-1';
+export const API_KEY_REGION = 'us-east';
 export const API_KEY_2 = process.env.API_KEY_2 || 'test-api-key-2';
+export const API_KEY_2_REGION = 'us-west';
 export const ADMIN_API_KEY = process.env.ADMIN_API_KEY || 'admin-test-key-1';
 export const INVALID_KEY = 'invalid-key-does-not-exist';
 

--- a/test/integration/utils/config.ts
+++ b/test/integration/utils/config.ts
@@ -2,9 +2,9 @@ export const BASE_URL =
   process.env.PROMPT_SERVICE_URL || 'http://localhost:3101';
 
 export const API_KEY = process.env.API_KEY || 'test-api-key-1';
-export const API_KEY_REGION = 'us-east';
+export const API_KEY_REGION = 'ca';
 export const API_KEY_2 = process.env.API_KEY_2 || 'test-api-key-2';
-export const API_KEY_2_REGION = 'us-west';
+export const API_KEY_2_REGION = 'tx';
 export const ADMIN_API_KEY = process.env.ADMIN_API_KEY || 'admin-test-key-1';
 export const INVALID_KEY = 'invalid-key-does-not-exist';
 


### PR DESCRIPTION
## Summary
- **Admin CRUD & A/B testing framework** — template management, versioning, rollback, experiment variants with deterministic bucketing
- **Prompt TTL** — configurable cache expiry via `PROMPT_TTL_SECONDS`
- **CI workflows** — lint, test, build, and integration test jobs
- **Docker-based integration tests** — 53 tests covering all 16 endpoints end-to-end
- **Per-region API key tracking** — `API_KEYS` uses `region:key` format (state abbreviations), region logged in `prompt_request_logs` for usage/abuse analytics

## Test plan
- [x] 75 unit tests pass
- [x] 53 integration tests pass
- [x] Lint and build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)