### PR TITLE
feat: node registry and certification system (#428)

### DIFF
--- a/prisma/migrations/20260228010000_add_node_registry/migration.sql
+++ b/prisma/migrations/20260228010000_add_node_registry/migration.sql
@@ -1,0 +1,52 @@
+-- CreateTable
+CREATE TABLE "nodes" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "region" TEXT NOT NULL,
+    "public_key" TEXT,
+    "api_key" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "certified_at" TIMESTAMPTZ,
+    "certification_expires_at" TIMESTAMPTZ,
+    "decertified_at" TIMESTAMPTZ,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "nodes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "node_audit_logs" (
+    "id" TEXT NOT NULL,
+    "node_id" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "reason" TEXT,
+    "performed_by" TEXT NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "node_audit_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "nodes_name_key" ON "nodes"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "nodes_api_key_key" ON "nodes"("api_key");
+
+-- CreateIndex
+CREATE INDEX "nodes_region_idx" ON "nodes"("region");
+
+-- CreateIndex
+CREATE INDEX "nodes_status_idx" ON "nodes"("status");
+
+-- CreateIndex
+CREATE INDEX "nodes_api_key_idx" ON "nodes"("api_key");
+
+-- CreateIndex
+CREATE INDEX "node_audit_logs_node_id_idx" ON "node_audit_logs"("node_id");
+
+-- CreateIndex
+CREATE INDEX "node_audit_logs_action_idx" ON "node_audit_logs"("action");
+
+-- AddForeignKey
+ALTER TABLE "node_audit_logs" ADD CONSTRAINT "node_audit_logs_node_id_fkey" FOREIGN KEY ("node_id") REFERENCES "nodes"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,3 +93,39 @@ model ExperimentVariant {
   @@index([experimentId])
   @@map("experiment_variants")
 }
+
+model Node {
+  id                     String    @id @default(uuid())
+  name                   String    @unique
+  region                 String
+  publicKey              String?   @map("public_key")
+  apiKey                 String    @unique @map("api_key")
+  status                 String    @default("pending") // pending, certified, decertified, expired
+  certifiedAt            DateTime? @map("certified_at") @db.Timestamptz
+  certificationExpiresAt DateTime? @map("certification_expires_at") @db.Timestamptz
+  decertifiedAt          DateTime? @map("decertified_at") @db.Timestamptz
+  createdAt              DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt              DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  auditLogs NodeAuditLog[]
+
+  @@index([region])
+  @@index([status])
+  @@index([apiKey])
+  @@map("nodes")
+}
+
+model NodeAuditLog {
+  id          String   @id @default(uuid())
+  nodeId      String   @map("node_id")
+  action      String   // registered, certified, decertified, recertified, key_rotated
+  reason      String?
+  performedBy String   @map("performed_by")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+
+  node Node @relation(fields: [nodeId], references: [id], onDelete: Cascade)
+
+  @@index([nodeId])
+  @@index([action])
+  @@map("node_audit_logs")
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller';
 import { ExperimentsAdminController } from './experiments-admin.controller';
+import { NodeRegistryController } from './node-registry.controller';
 import { AdminService } from './admin.service';
+import { NodeRegistryService } from './node-registry.service';
 
 @Module({
-  controllers: [AdminController, ExperimentsAdminController],
-  providers: [AdminService],
+  controllers: [
+    AdminController,
+    ExperimentsAdminController,
+    NodeRegistryController,
+  ],
+  providers: [AdminService, NodeRegistryService],
 })
 export class AdminModule {}

--- a/src/admin/dto/certify-node.dto.ts
+++ b/src/admin/dto/certify-node.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsNumber, Min } from 'class-validator';
+
+export class CertifyNodeDto {
+  @ApiPropertyOptional({
+    description: 'Certification validity in days (default: 365)',
+    default: 365,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  expiresInDays?: number;
+
+  @ApiPropertyOptional({ description: 'Reason for certification' })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/admin/dto/create-node.dto.ts
+++ b/src/admin/dto/create-node.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, Matches } from 'class-validator';
+
+export class CreateNodeDto {
+  @ApiProperty({ description: 'Unique node name (e.g., node-ca-01)' })
+  @IsString()
+  @Matches(/^[a-z0-9-]+$/, {
+    message: 'Name must be lowercase alphanumeric with hyphens',
+  })
+  name: string;
+
+  @ApiProperty({ description: 'Region identifier (e.g., ca, tx, ny)' })
+  @IsString()
+  region: string;
+
+  @ApiPropertyOptional({
+    description: 'Node public key for signature verification',
+  })
+  @IsOptional()
+  @IsString()
+  publicKey?: string;
+}

--- a/src/admin/dto/decertify-node.dto.ts
+++ b/src/admin/dto/decertify-node.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class DecertifyNodeDto {
+  @ApiProperty({ description: 'Reason for decertification (required)' })
+  @IsString()
+  reason: string;
+}

--- a/src/admin/dto/list-nodes-query.dto.ts
+++ b/src/admin/dto/list-nodes-query.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class ListNodesQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by region' })
+  @IsOptional()
+  @IsString()
+  region?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by status (pending, certified, decertified, expired)',
+  })
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/src/admin/dto/update-node.dto.ts
+++ b/src/admin/dto/update-node.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, Matches } from 'class-validator';
+
+export class UpdateNodeDto {
+  @ApiPropertyOptional({ description: 'Updated node name' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[a-z0-9-]+$/, {
+    message: 'Name must be lowercase alphanumeric with hyphens',
+  })
+  name?: string;
+
+  @ApiPropertyOptional({ description: 'Updated region identifier' })
+  @IsOptional()
+  @IsString()
+  region?: string;
+
+  @ApiPropertyOptional({ description: 'Updated public key' })
+  @IsOptional()
+  @IsString()
+  publicKey?: string;
+}

--- a/src/admin/node-registry.controller.spec.ts
+++ b/src/admin/node-registry.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { NodeRegistryController } from './node-registry.controller';
 import { NodeRegistryService } from './node-registry.service';
 
@@ -153,5 +154,63 @@ describe('NodeRegistryController', () => {
 
     expect(service.deleteNode).toHaveBeenCalledWith('1');
     expect(result).toEqual(expected);
+  });
+
+  describe('error propagation', () => {
+    it('should propagate NotFoundException from getNode', async () => {
+      jest
+        .spyOn(service, 'getNode')
+        .mockRejectedValue(new NotFoundException('Node not-found not found'));
+
+      await expect(controller.getById('not-found')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should propagate NotFoundException from certifyNode', async () => {
+      jest
+        .spyOn(service, 'certifyNode')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.certify('not-found', {}, { adminKey: 'admin-key-12345' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate BadRequestException from certifyNode on decertified node', async () => {
+      jest
+        .spyOn(service, 'certifyNode')
+        .mockRejectedValue(
+          new BadRequestException('Cannot certify a decertified node'),
+        );
+
+      await expect(
+        controller.certify('1', {}, { adminKey: 'admin-key-12345' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should propagate NotFoundException from decertifyNode', async () => {
+      jest
+        .spyOn(service, 'decertifyNode')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.decertify(
+          'not-found',
+          { reason: 'test' },
+          { adminKey: 'admin-key-12345' },
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate NotFoundException from deleteNode', async () => {
+      jest
+        .spyOn(service, 'deleteNode')
+        .mockRejectedValue(new NotFoundException());
+
+      await expect(controller.delete('not-found')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/src/admin/node-registry.controller.spec.ts
+++ b/src/admin/node-registry.controller.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NodeRegistryController } from './node-registry.controller';
+import { NodeRegistryService } from './node-registry.service';
+
+describe('NodeRegistryController', () => {
+  let controller: NodeRegistryController;
+  let service: NodeRegistryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NodeRegistryController],
+      providers: [
+        {
+          provide: NodeRegistryService,
+          useValue: {
+            registerNode: jest.fn(),
+            listNodes: jest.fn(),
+            getNode: jest.fn(),
+            updateNode: jest.fn(),
+            certifyNode: jest.fn(),
+            decertifyNode: jest.fn(),
+            recertifyNode: jest.fn(),
+            rotateApiKey: jest.fn(),
+            deleteNode: jest.fn(),
+            getHealthDashboard: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('admin-test-key') },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(NodeRegistryController);
+    service = module.get(NodeRegistryService);
+  });
+
+  it('should call registerNode with dto and admin key prefix', async () => {
+    const dto = { name: 'node-ca-01', region: 'ca' };
+    const expected = { id: '1', ...dto, apiKey: 'key', status: 'pending' };
+    jest.spyOn(service, 'registerNode').mockResolvedValue(expected as never);
+
+    const result = await controller.register(dto, {
+      adminKey: 'admin-test-key-123',
+    });
+
+    expect(service.registerNode).toHaveBeenCalledWith(dto, 'admin-te...');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call listNodes with query', async () => {
+    const query = { region: 'ca' };
+    const expected = [{ id: '1', name: 'node-ca-01' }];
+    jest.spyOn(service, 'listNodes').mockResolvedValue(expected as never);
+
+    const result = await controller.list(query);
+
+    expect(service.listNodes).toHaveBeenCalledWith(query);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getHealthDashboard', async () => {
+    const expected = { totalNodes: 5, byStatus: {} };
+    jest
+      .spyOn(service, 'getHealthDashboard')
+      .mockResolvedValue(expected as never);
+
+    const result = await controller.healthDashboard();
+
+    expect(service.getHealthDashboard).toHaveBeenCalled();
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getNode with id', async () => {
+    const expected = { id: '1', name: 'node-ca-01', auditLogs: [] };
+    jest.spyOn(service, 'getNode').mockResolvedValue(expected as never);
+
+    const result = await controller.getById('1');
+
+    expect(service.getNode).toHaveBeenCalledWith('1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call updateNode with id and dto', async () => {
+    const dto = { name: 'updated-name' };
+    const expected = { id: '1', name: 'updated-name' };
+    jest.spyOn(service, 'updateNode').mockResolvedValue(expected as never);
+
+    const result = await controller.update('1', dto);
+
+    expect(service.updateNode).toHaveBeenCalledWith('1', dto);
+    expect(result).toEqual(expected);
+  });
+
+  it('should call certifyNode with id, dto, and admin key prefix', async () => {
+    const dto = { expiresInDays: 90 };
+    const expected = { id: '1', status: 'certified' };
+    jest.spyOn(service, 'certifyNode').mockResolvedValue(expected as never);
+
+    const result = await controller.certify('1', dto, {
+      adminKey: 'admin-test-key-123',
+    });
+
+    expect(service.certifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call decertifyNode with id, dto, and admin key prefix', async () => {
+    const dto = { reason: 'Terms violation' };
+    const expected = { id: '1', status: 'decertified' };
+    jest.spyOn(service, 'decertifyNode').mockResolvedValue(expected as never);
+
+    const result = await controller.decertify('1', dto, {
+      adminKey: 'admin-test-key-123',
+    });
+
+    expect(service.decertifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call recertifyNode with id, dto, and admin key prefix', async () => {
+    const dto = { expiresInDays: 365 };
+    const expected = { id: '1', status: 'certified' };
+    jest.spyOn(service, 'recertifyNode').mockResolvedValue(expected as never);
+
+    const result = await controller.recertify('1', dto, {
+      adminKey: 'admin-test-key-123',
+    });
+
+    expect(service.recertifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call rotateApiKey with id and admin key prefix', async () => {
+    const expected = { id: '1', apiKey: 'new-key' };
+    jest.spyOn(service, 'rotateApiKey').mockResolvedValue(expected as never);
+
+    const result = await controller.rotateKey('1', {
+      adminKey: 'admin-test-key-123',
+    });
+
+    expect(service.rotateApiKey).toHaveBeenCalledWith('1', 'admin-te...');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call deleteNode with id', async () => {
+    const expected = { deleted: true };
+    jest.spyOn(service, 'deleteNode').mockResolvedValue(expected as never);
+
+    const result = await controller.delete('1');
+
+    expect(service.deleteNode).toHaveBeenCalledWith('1');
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/admin/node-registry.controller.ts
+++ b/src/admin/node-registry.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AdminKeyGuard } from '../auth/admin-key.guard';
+import { NodeRegistryService } from './node-registry.service';
+import { CreateNodeDto } from './dto/create-node.dto';
+import { UpdateNodeDto } from './dto/update-node.dto';
+import { ListNodesQueryDto } from './dto/list-nodes-query.dto';
+import { CertifyNodeDto } from './dto/certify-node.dto';
+import { DecertifyNodeDto } from './dto/decertify-node.dto';
+
+@ApiTags('admin - nodes')
+@Controller('admin/nodes')
+@UseGuards(AdminKeyGuard)
+@ApiBearerAuth()
+export class NodeRegistryController {
+  constructor(private readonly nodeRegistry: NodeRegistryService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Register a new node' })
+  @ApiResponse({
+    status: 201,
+    description: 'Node registered with generated API key',
+  })
+  async register(@Body() dto: CreateNodeDto, @Req() req: { adminKey: string }) {
+    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
+    return this.nodeRegistry.registerNode(dto, adminKeyPrefix);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all nodes' })
+  async list(@Query() query: ListNodesQueryDto) {
+    return this.nodeRegistry.listNodes(query);
+  }
+
+  @Get('health')
+  @ApiOperation({ summary: 'Node health dashboard' })
+  async healthDashboard() {
+    return this.nodeRegistry.getHealthDashboard();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get node details with audit log' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async getById(@Param('id') id: string) {
+    return this.nodeRegistry.getNode(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update node metadata' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async update(@Param('id') id: string, @Body() dto: UpdateNodeDto) {
+    return this.nodeRegistry.updateNode(id, dto);
+  }
+
+  @Post(':id/certify')
+  @ApiOperation({ summary: 'Certify a node (enable its API key)' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async certify(
+    @Param('id') id: string,
+    @Body() dto: CertifyNodeDto,
+    @Req() req: { adminKey: string },
+  ) {
+    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
+    return this.nodeRegistry.certifyNode(id, dto, adminKeyPrefix);
+  }
+
+  @Post(':id/decertify')
+  @ApiOperation({ summary: 'Decertify a node (revoke its API key)' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async decertify(
+    @Param('id') id: string,
+    @Body() dto: DecertifyNodeDto,
+    @Req() req: { adminKey: string },
+  ) {
+    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
+    return this.nodeRegistry.decertifyNode(id, dto, adminKeyPrefix);
+  }
+
+  @Post(':id/recertify')
+  @ApiOperation({ summary: 'Re-certify a node (renew certification)' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async recertify(
+    @Param('id') id: string,
+    @Body() dto: CertifyNodeDto,
+    @Req() req: { adminKey: string },
+  ) {
+    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
+    return this.nodeRegistry.recertifyNode(id, dto, adminKeyPrefix);
+  }
+
+  @Post(':id/rotate-key')
+  @ApiOperation({ summary: 'Rotate a node API key' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async rotateKey(@Param('id') id: string, @Req() req: { adminKey: string }) {
+    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
+    return this.nodeRegistry.rotateApiKey(id, adminKeyPrefix);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a node' })
+  @ApiResponse({ status: 404, description: 'Node not found' })
+  async delete(@Param('id') id: string) {
+    return this.nodeRegistry.deleteNode(id);
+  }
+}

--- a/src/admin/node-registry.service.spec.ts
+++ b/src/admin/node-registry.service.spec.ts
@@ -1,0 +1,394 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { NodeRegistryService } from './node-registry.service';
+
+function createMockPrisma() {
+  const txMethods = {
+    node: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    nodeAuditLog: {
+      create: jest.fn(),
+    },
+  };
+
+  return {
+    node: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn(),
+      groupBy: jest.fn(),
+    },
+    nodeAuditLog: {},
+    $transaction: jest.fn((cb: (tx: typeof txMethods) => unknown) =>
+      cb(txMethods),
+    ),
+    _tx: txMethods,
+  };
+}
+
+describe('NodeRegistryService', () => {
+  let service: NodeRegistryService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new NodeRegistryService(prisma as never);
+  });
+
+  describe('registerNode', () => {
+    it('should create node with generated API key and audit log', async () => {
+      const dto = { name: 'node-ca-01', region: 'ca' };
+      const created = {
+        id: 'uuid-1',
+        ...dto,
+        apiKey: 'generated-key',
+        status: 'pending',
+      };
+
+      prisma._tx.node.create.mockResolvedValue(created);
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.registerNode(dto, 'admin-te...');
+
+      expect(result).toEqual(created);
+      expect(prisma._tx.node.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          name: 'node-ca-01',
+          region: 'ca',
+          publicKey: null,
+          status: 'pending',
+          apiKey: expect.any(String),
+        }),
+      });
+      expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          nodeId: 'uuid-1',
+          action: 'registered',
+          performedBy: 'admin-te...',
+        },
+      });
+    });
+
+    it('should pass publicKey when provided', async () => {
+      const dto = { name: 'node-tx-01', region: 'tx', publicKey: 'pk-123' };
+      prisma._tx.node.create.mockResolvedValue({ id: '1', ...dto });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      await service.registerNode(dto, 'admin...');
+
+      expect(prisma._tx.node.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ publicKey: 'pk-123' }),
+      });
+    });
+  });
+
+  describe('listNodes', () => {
+    it('should return all nodes when no filters', async () => {
+      const nodes = [{ id: '1', name: 'node-a' }];
+      prisma.node.findMany.mockResolvedValue(nodes);
+
+      const result = await service.listNodes({});
+
+      expect(prisma.node.findMany).toHaveBeenCalledWith({
+        where: {},
+        orderBy: { name: 'asc' },
+      });
+      expect(result).toEqual(nodes);
+    });
+
+    it('should filter by region', async () => {
+      prisma.node.findMany.mockResolvedValue([]);
+
+      await service.listNodes({ region: 'ca' });
+
+      expect(prisma.node.findMany).toHaveBeenCalledWith({
+        where: { region: 'ca' },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('should filter by status', async () => {
+      prisma.node.findMany.mockResolvedValue([]);
+
+      await service.listNodes({ status: 'certified' });
+
+      expect(prisma.node.findMany).toHaveBeenCalledWith({
+        where: { status: 'certified' },
+        orderBy: { name: 'asc' },
+      });
+    });
+  });
+
+  describe('getNode', () => {
+    it('should return node with audit logs', async () => {
+      const node = {
+        id: '1',
+        name: 'node-ca-01',
+        auditLogs: [{ action: 'registered' }],
+      };
+      prisma.node.findUnique.mockResolvedValue(node);
+
+      const result = await service.getNode('1');
+
+      expect(result).toEqual(node);
+      expect(prisma.node.findUnique).toHaveBeenCalledWith({
+        where: { id: '1' },
+        include: { auditLogs: { orderBy: { createdAt: 'desc' }, take: 20 } },
+      });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma.node.findUnique.mockResolvedValue(null);
+
+      await expect(service.getNode('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateNode', () => {
+    it('should update name and region', async () => {
+      prisma.node.findUnique.mockResolvedValue({ id: '1', name: 'old' });
+      prisma.node.update.mockResolvedValue({
+        id: '1',
+        name: 'new',
+        region: 'tx',
+      });
+
+      const result = await service.updateNode('1', {
+        name: 'new',
+        region: 'tx',
+      });
+
+      expect(result.name).toBe('new');
+      expect(prisma.node.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { name: 'new', region: 'tx' },
+      });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma.node.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.updateNode('nonexistent', { name: 'new' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('certifyNode', () => {
+    it('should set status to certified with expiration', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'pending',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.certifyNode(
+        '1',
+        { expiresInDays: 90 },
+        'admin...',
+      );
+
+      expect(result.status).toBe('certified');
+      expect(prisma._tx.node.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: {
+          status: 'certified',
+          certifiedAt: expect.any(Date),
+          certificationExpiresAt: expect.any(Date),
+        },
+      });
+      expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          nodeId: '1',
+          action: 'certified',
+          reason: undefined,
+          performedBy: 'admin...',
+        },
+      });
+    });
+
+    it('should reject certifying a decertified node', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'decertified',
+      });
+
+      await expect(service.certifyNode('1', {}, 'admin...')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.certifyNode('nonexistent', {}, 'admin...'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('decertifyNode', () => {
+    it('should set status to decertified with audit log', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        status: 'decertified',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.decertifyNode(
+        '1',
+        { reason: 'Terms violation' },
+        'admin...',
+      );
+
+      expect(result.status).toBe('decertified');
+      expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          nodeId: '1',
+          action: 'decertified',
+          reason: 'Terms violation',
+          performedBy: 'admin...',
+        },
+      });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.decertifyNode('nonexistent', { reason: 'test' }, 'admin...'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('recertifyNode', () => {
+    it('should re-certify and clear decertifiedAt', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'decertified',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+        decertifiedAt: null,
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.recertifyNode('1', {}, 'admin...');
+
+      expect(result.status).toBe('certified');
+      expect(prisma._tx.node.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: {
+          status: 'certified',
+          certifiedAt: expect.any(Date),
+          certificationExpiresAt: expect.any(Date),
+          decertifiedAt: null,
+        },
+      });
+      expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          nodeId: '1',
+          action: 'recertified',
+          reason: undefined,
+          performedBy: 'admin...',
+        },
+      });
+    });
+  });
+
+  describe('rotateApiKey', () => {
+    it('should generate a new API key and create audit log', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        apiKey: 'old-key',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        apiKey: 'new-key',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.rotateApiKey('1', 'admin...');
+
+      expect(prisma._tx.node.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { apiKey: expect.any(String) },
+      });
+      expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
+        data: {
+          nodeId: '1',
+          action: 'key_rotated',
+          performedBy: 'admin...',
+        },
+      });
+      expect(result.apiKey).toBeDefined();
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.rotateApiKey('nonexistent', 'admin...'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('deleteNode', () => {
+    it('should delete node and return confirmation', async () => {
+      prisma.node.findUnique.mockResolvedValue({ id: '1' });
+      prisma.node.delete.mockResolvedValue({});
+
+      const result = await service.deleteNode('1');
+
+      expect(result).toEqual({ deleted: true });
+      expect(prisma.node.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma.node.findUnique.mockResolvedValue(null);
+
+      await expect(service.deleteNode('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('getHealthDashboard', () => {
+    it('should return aggregated node status info', async () => {
+      prisma.node.count.mockResolvedValue(5);
+      prisma.node.groupBy.mockResolvedValue([
+        { status: 'certified', _count: 3 },
+        { status: 'pending', _count: 2 },
+      ]);
+      prisma.node.findMany
+        .mockResolvedValueOnce([{ id: '1', name: 'expiring-node' }])
+        .mockResolvedValueOnce([{ id: '2', name: 'new-node' }]);
+
+      const result = await service.getHealthDashboard();
+
+      expect(result.totalNodes).toBe(5);
+      expect(result.byStatus).toEqual({ certified: 3, pending: 2 });
+      expect(result.expiringIn30Days).toEqual([
+        { id: '1', name: 'expiring-node' },
+      ]);
+      expect(result.recentlyRegistered).toEqual([
+        { id: '2', name: 'new-node' },
+      ]);
+    });
+  });
+});

--- a/src/admin/node-registry.service.spec.ts
+++ b/src/admin/node-registry.service.spec.ts
@@ -86,6 +86,36 @@ describe('NodeRegistryService', () => {
     });
   });
 
+  describe('generateApiKey', () => {
+    it('should generate a 64-character hex string', async () => {
+      const dto = { name: 'node-key-test', region: 'ca' };
+      prisma._tx.node.create.mockResolvedValue({
+        id: '1',
+        ...dto,
+        apiKey: '',
+        status: 'pending',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      await service.registerNode(dto, 'admin...');
+
+      const createCall = prisma._tx.node.create.mock.calls[0][0];
+      expect(createCall.data.apiKey).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should generate unique keys on each call', async () => {
+      prisma._tx.node.create.mockResolvedValue({ id: '1' });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      await service.registerNode({ name: 'a', region: 'ca' }, 'admin...');
+      await service.registerNode({ name: 'b', region: 'ca' }, 'admin...');
+
+      const key1 = prisma._tx.node.create.mock.calls[0][0].data.apiKey;
+      const key2 = prisma._tx.node.create.mock.calls[1][0].data.apiKey;
+      expect(key1).not.toBe(key2);
+    });
+  });
+
   describe('listNodes', () => {
     it('should return all nodes when no filters', async () => {
       const nodes = [{ id: '1', name: 'node-a' }];
@@ -118,6 +148,17 @@ describe('NodeRegistryService', () => {
 
       expect(prisma.node.findMany).toHaveBeenCalledWith({
         where: { status: 'certified' },
+        orderBy: { name: 'asc' },
+      });
+    });
+
+    it('should filter by region and status together', async () => {
+      prisma.node.findMany.mockResolvedValue([]);
+
+      await service.listNodes({ region: 'ca', status: 'certified' });
+
+      expect(prisma.node.findMany).toHaveBeenCalledWith({
+        where: { region: 'ca', status: 'certified' },
         orderBy: { name: 'asc' },
       });
     });
@@ -171,6 +212,18 @@ describe('NodeRegistryService', () => {
       });
     });
 
+    it('should update only publicKey when other fields are undefined', async () => {
+      prisma.node.findUnique.mockResolvedValue({ id: '1' });
+      prisma.node.update.mockResolvedValue({ id: '1', publicKey: 'new-pk' });
+
+      await service.updateNode('1', { publicKey: 'new-pk' });
+
+      expect(prisma.node.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { publicKey: 'new-pk' },
+      });
+    });
+
     it('should throw NotFoundException when not found', async () => {
       prisma.node.findUnique.mockResolvedValue(null);
 
@@ -215,6 +268,45 @@ describe('NodeRegistryService', () => {
           performedBy: 'admin...',
         },
       });
+    });
+
+    it('should use default 365-day expiration when not specified', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'pending',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      await service.certifyNode('1', {}, 'admin...');
+
+      const updateCall = prisma._tx.node.update.mock.calls[0][0];
+      const expiresAt = new Date(updateCall.data.certificationExpiresAt);
+      const now = new Date();
+      const diffDays = Math.round(
+        (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60 * 24),
+      );
+      expect(diffDays).toBeGreaterThanOrEqual(364);
+      expect(diffDays).toBeLessThanOrEqual(366);
+    });
+
+    it('should allow re-certifying an already certified node', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+      });
+      prisma._tx.node.update.mockResolvedValue({
+        id: '1',
+        status: 'certified',
+      });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      const result = await service.certifyNode('1', {}, 'admin...');
+
+      expect(result.status).toBe('certified');
     });
 
     it('should reject certifying a decertified node', async () => {
@@ -309,6 +401,14 @@ describe('NodeRegistryService', () => {
         },
       });
     });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma._tx.node.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.recertifyNode('nonexistent', {}, 'admin...'),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   describe('rotateApiKey', () => {
@@ -389,6 +489,19 @@ describe('NodeRegistryService', () => {
       expect(result.recentlyRegistered).toEqual([
         { id: '2', name: 'new-node' },
       ]);
+    });
+
+    it('should handle empty database gracefully', async () => {
+      prisma.node.count.mockResolvedValue(0);
+      prisma.node.groupBy.mockResolvedValue([]);
+      prisma.node.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getHealthDashboard();
+
+      expect(result.totalNodes).toBe(0);
+      expect(result.byStatus).toEqual({});
+      expect(result.expiringIn30Days).toEqual([]);
+      expect(result.recentlyRegistered).toEqual([]);
     });
   });
 });

--- a/src/admin/node-registry.service.ts
+++ b/src/admin/node-registry.service.ts
@@ -1,0 +1,268 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { PrismaService } from '../common/prisma.service';
+import { CreateNodeDto } from './dto/create-node.dto';
+import { UpdateNodeDto } from './dto/update-node.dto';
+import { ListNodesQueryDto } from './dto/list-nodes-query.dto';
+import { CertifyNodeDto } from './dto/certify-node.dto';
+import { DecertifyNodeDto } from './dto/decertify-node.dto';
+
+@Injectable()
+export class NodeRegistryService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private generateApiKey(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  async registerNode(dto: CreateNodeDto, adminKeyPrefix: string) {
+    const apiKey = this.generateApiKey();
+
+    return this.prisma.$transaction(async (tx) => {
+      const node = await tx.node.create({
+        data: {
+          name: dto.name,
+          region: dto.region,
+          publicKey: dto.publicKey ?? null,
+          apiKey,
+          status: 'pending',
+        },
+      });
+
+      await tx.nodeAuditLog.create({
+        data: {
+          nodeId: node.id,
+          action: 'registered',
+          performedBy: adminKeyPrefix,
+        },
+      });
+
+      return node;
+    });
+  }
+
+  async listNodes(query: ListNodesQueryDto) {
+    const where: Record<string, unknown> = {};
+    if (query.region) where.region = query.region;
+    if (query.status) where.status = query.status;
+
+    return this.prisma.node.findMany({
+      where,
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async getNode(id: string) {
+    const node = await this.prisma.node.findUnique({
+      where: { id },
+      include: {
+        auditLogs: { orderBy: { createdAt: 'desc' }, take: 20 },
+      },
+    });
+    if (!node) throw new NotFoundException(`Node ${id} not found`);
+    return node;
+  }
+
+  async updateNode(id: string, dto: UpdateNodeDto) {
+    const node = await this.prisma.node.findUnique({ where: { id } });
+    if (!node) throw new NotFoundException(`Node ${id} not found`);
+
+    const data: Record<string, unknown> = {};
+    if (dto.name !== undefined) data.name = dto.name;
+    if (dto.region !== undefined) data.region = dto.region;
+    if (dto.publicKey !== undefined) data.publicKey = dto.publicKey;
+
+    return this.prisma.node.update({ where: { id }, data });
+  }
+
+  async certifyNode(id: string, dto: CertifyNodeDto, adminKeyPrefix: string) {
+    return this.prisma.$transaction(async (tx) => {
+      const node = await tx.node.findUnique({ where: { id } });
+      if (!node) throw new NotFoundException(`Node ${id} not found`);
+      if (node.status === 'decertified') {
+        throw new BadRequestException(
+          'Cannot certify a decertified node. Use recertify instead.',
+        );
+      }
+
+      const expiresInDays = dto.expiresInDays ?? 365;
+      const certificationExpiresAt = new Date();
+      certificationExpiresAt.setDate(
+        certificationExpiresAt.getDate() + expiresInDays,
+      );
+
+      const updated = await tx.node.update({
+        where: { id },
+        data: {
+          status: 'certified',
+          certifiedAt: new Date(),
+          certificationExpiresAt,
+        },
+      });
+
+      await tx.nodeAuditLog.create({
+        data: {
+          nodeId: id,
+          action: 'certified',
+          reason: dto.reason,
+          performedBy: adminKeyPrefix,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async decertifyNode(
+    id: string,
+    dto: DecertifyNodeDto,
+    adminKeyPrefix: string,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const node = await tx.node.findUnique({ where: { id } });
+      if (!node) throw new NotFoundException(`Node ${id} not found`);
+
+      const updated = await tx.node.update({
+        where: { id },
+        data: {
+          status: 'decertified',
+          decertifiedAt: new Date(),
+        },
+      });
+
+      await tx.nodeAuditLog.create({
+        data: {
+          nodeId: id,
+          action: 'decertified',
+          reason: dto.reason,
+          performedBy: adminKeyPrefix,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async recertifyNode(id: string, dto: CertifyNodeDto, adminKeyPrefix: string) {
+    return this.prisma.$transaction(async (tx) => {
+      const node = await tx.node.findUnique({ where: { id } });
+      if (!node) throw new NotFoundException(`Node ${id} not found`);
+
+      const expiresInDays = dto.expiresInDays ?? 365;
+      const certificationExpiresAt = new Date();
+      certificationExpiresAt.setDate(
+        certificationExpiresAt.getDate() + expiresInDays,
+      );
+
+      const updated = await tx.node.update({
+        where: { id },
+        data: {
+          status: 'certified',
+          certifiedAt: new Date(),
+          certificationExpiresAt,
+          decertifiedAt: null,
+        },
+      });
+
+      await tx.nodeAuditLog.create({
+        data: {
+          nodeId: id,
+          action: 'recertified',
+          reason: dto.reason,
+          performedBy: adminKeyPrefix,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async rotateApiKey(id: string, adminKeyPrefix: string) {
+    return this.prisma.$transaction(async (tx) => {
+      const node = await tx.node.findUnique({ where: { id } });
+      if (!node) throw new NotFoundException(`Node ${id} not found`);
+
+      const newApiKey = this.generateApiKey();
+
+      const updated = await tx.node.update({
+        where: { id },
+        data: { apiKey: newApiKey },
+      });
+
+      await tx.nodeAuditLog.create({
+        data: {
+          nodeId: id,
+          action: 'key_rotated',
+          performedBy: adminKeyPrefix,
+        },
+      });
+
+      return updated;
+    });
+  }
+
+  async deleteNode(id: string) {
+    const node = await this.prisma.node.findUnique({ where: { id } });
+    if (!node) throw new NotFoundException(`Node ${id} not found`);
+    await this.prisma.node.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  async getHealthDashboard() {
+    const [totalCount, byStatus, expiringIn30Days, recentlyRegistered] =
+      await Promise.all([
+        this.prisma.node.count(),
+        this.prisma.node.groupBy({
+          by: ['status'],
+          _count: true,
+        }),
+        this.prisma.node.findMany({
+          where: {
+            status: 'certified',
+            certificationExpiresAt: {
+              lte: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+              gt: new Date(),
+            },
+          },
+          select: {
+            id: true,
+            name: true,
+            region: true,
+            certificationExpiresAt: true,
+          },
+          orderBy: { certificationExpiresAt: 'asc' },
+        }),
+        this.prisma.node.findMany({
+          where: {
+            createdAt: {
+              gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+            },
+          },
+          select: {
+            id: true,
+            name: true,
+            region: true,
+            status: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: 'desc' },
+        }),
+      ]);
+
+    const statusCounts: Record<string, number> = {};
+    for (const entry of byStatus) {
+      statusCounts[entry.status] = entry._count;
+    }
+
+    return {
+      totalNodes: totalCount,
+      byStatus: statusCounts,
+      expiringIn30Days,
+      recentlyRegistered,
+    };
+  }
+}

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -2,74 +2,133 @@ import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiKeyGuard } from './api-key.guard';
 
-function createMockContext(authHeader?: string): ExecutionContext {
+function createMockPrisma() {
+  return {
+    node: {
+      findFirst: jest.fn(),
+    },
+  };
+}
+
+function createMockContext(authHeader?: string) {
   const request: Record<string, unknown> = {
     headers: authHeader ? { authorization: authHeader } : {},
   };
 
   return {
-    switchToHttp: () => ({ getRequest: () => request }),
-  } as unknown as ExecutionContext;
+    ctx: {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext,
+    request,
+  };
 }
 
 describe('ApiKeyGuard', () => {
   let guard: ApiKeyGuard;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
 
   beforeEach(() => {
     const configService = {
       get: jest.fn().mockReturnValue('ca:key-1,tx:key-2,ny:key-3'),
     } as unknown as ConfigService;
-    guard = new ApiKeyGuard(configService);
+    mockPrisma = createMockPrisma();
+    guard = new ApiKeyGuard(configService, mockPrisma as never);
   });
 
-  it('should allow a valid API key', () => {
-    const ctx = createMockContext('Bearer key-1');
-    expect(guard.canActivate(ctx)).toBe(true);
+  it('should allow a valid env var API key', async () => {
+    const { ctx } = createMockContext('Bearer key-1');
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
-  it('should reject missing Authorization header', () => {
-    const ctx = createMockContext();
-    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  it('should reject missing Authorization header', async () => {
+    const { ctx } = createMockContext();
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('should reject non-Bearer auth', () => {
-    const ctx = createMockContext('Basic abc123');
-    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  it('should reject non-Bearer auth', async () => {
+    const { ctx } = createMockContext('Basic abc123');
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('should reject invalid API key', () => {
-    const ctx = createMockContext('Bearer invalid-key');
-    expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+  it('should reject invalid API key not in env or DB', async () => {
+    mockPrisma.node.findFirst.mockResolvedValue(null);
+    const { ctx } = createMockContext('Bearer invalid-key');
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('should attach apiKey and region to request on success', () => {
-    const request: Record<string, unknown> = {
-      headers: { authorization: 'Bearer key-2' },
-    };
-    const ctx = {
-      switchToHttp: () => ({ getRequest: () => request }),
-    } as unknown as ExecutionContext;
+  it('should attach apiKey and region to request for env var keys', async () => {
+    const { ctx, request } = createMockContext('Bearer key-2');
 
-    guard.canActivate(ctx);
+    await guard.canActivate(ctx);
+
     expect(request.apiKey).toBe('key-2');
     expect(request.region).toBe('tx');
+    expect(request.nodeId).toBeUndefined();
   });
 
-  it('should default to unknown region when no colon in key entry', () => {
+  it('should default to unknown region when no colon in key entry', async () => {
     const configService = {
       get: jest.fn().mockReturnValue('legacy-key'),
     } as unknown as ConfigService;
-    const legacyGuard = new ApiKeyGuard(configService);
+    const legacyGuard = new ApiKeyGuard(
+      configService,
+      createMockPrisma() as never,
+    );
 
-    const request: Record<string, unknown> = {
-      headers: { authorization: 'Bearer legacy-key' },
-    };
-    const ctx = {
-      switchToHttp: () => ({ getRequest: () => request }),
-    } as unknown as ExecutionContext;
+    const { ctx, request } = createMockContext('Bearer legacy-key');
 
-    legacyGuard.canActivate(ctx);
+    await legacyGuard.canActivate(ctx);
+
     expect(request.apiKey).toBe('legacy-key');
     expect(request.region).toBe('unknown');
+  });
+
+  describe('DB-backed node keys', () => {
+    it('should authenticate with a valid certified node API key', async () => {
+      mockPrisma.node.findFirst.mockResolvedValue({
+        id: 'node-uuid-1',
+        region: 'ca',
+        apiKey: 'node-api-key',
+        status: 'certified',
+      });
+      const { ctx, request } = createMockContext('Bearer node-api-key');
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(request.apiKey).toBe('node-api-key');
+      expect(request.region).toBe('ca');
+      expect(request.nodeId).toBe('node-uuid-1');
+    });
+
+    it('should query DB only when key not found in env vars', async () => {
+      const { ctx } = createMockContext('Bearer key-1');
+
+      await guard.canActivate(ctx);
+
+      expect(mockPrisma.node.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('should reject when node is not certified', async () => {
+      mockPrisma.node.findFirst.mockResolvedValue(null);
+      const { ctx } = createMockContext('Bearer uncertified-node-key');
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should query with correct certified + non-expired criteria', async () => {
+      mockPrisma.node.findFirst.mockResolvedValue(null);
+      const { ctx } = createMockContext('Bearer some-node-key');
+
+      await guard.canActivate(ctx).catch(() => {});
+
+      expect(mockPrisma.node.findFirst).toHaveBeenCalledWith({
+        where: {
+          apiKey: 'some-node-key',
+          status: 'certified',
+          certificationExpiresAt: { gt: expect.any(Date) },
+        },
+      });
+    });
   });
 });

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -66,6 +66,44 @@ describe('ApiKeyGuard', () => {
     expect(request.nodeId).toBeUndefined();
   });
 
+  it('should reject Bearer token with no key after space', async () => {
+    mockPrisma.node.findFirst.mockResolvedValue(null);
+    const { ctx } = createMockContext('Bearer ');
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should handle empty API_KEYS config gracefully', async () => {
+    const configService = {
+      get: jest.fn().mockReturnValue(''),
+    } as unknown as ConfigService;
+    const emptyGuard = new ApiKeyGuard(
+      configService,
+      createMockPrisma() as never,
+    );
+
+    const { ctx } = createMockContext('Bearer some-key');
+    // Should fall through to DB lookup since no env keys configured
+    await expect(emptyGuard.canActivate(ctx)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should handle API_KEYS with multiple colons (key contains colon)', async () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('ca:key:with:colons'),
+    } as unknown as ConfigService;
+    const colonGuard = new ApiKeyGuard(
+      configService,
+      createMockPrisma() as never,
+    );
+
+    const { ctx, request } = createMockContext('Bearer key:with:colons');
+    await colonGuard.canActivate(ctx);
+
+    expect(request.apiKey).toBe('key:with:colons');
+    expect(request.region).toBe('ca');
+  });
+
   it('should default to unknown region when no colon in key entry', async () => {
     const configService = {
       get: jest.fn().mockReturnValue('legacy-key'),
@@ -129,6 +167,35 @@ describe('ApiKeyGuard', () => {
           certificationExpiresAt: { gt: expect.any(Date) },
         },
       });
+    });
+
+    it('should reject expired node certification (DB returns null for expired)', async () => {
+      // When certificationExpiresAt is in the past, findFirst returns null
+      mockPrisma.node.findFirst.mockResolvedValue(null);
+      const { ctx } = createMockContext('Bearer expired-node-key');
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should reject pending node key (DB returns null for non-certified)', async () => {
+      // When status is 'pending', findFirst returns null
+      mockPrisma.node.findFirst.mockResolvedValue(null);
+      const { ctx } = createMockContext('Bearer pending-node-key');
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should not set nodeId for env var keys', async () => {
+      const { ctx, request } = createMockContext('Bearer key-3');
+
+      await guard.canActivate(ctx);
+
+      expect(request.nodeId).toBeUndefined();
+      expect(request.region).toBe('ny');
     });
   });
 });

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -5,12 +5,16 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../common/prisma.service';
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
   private readonly keyToRegion: Map<string, string>;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {
     const keys = this.config.get<string>('API_KEYS', '');
     this.keyToRegion = new Map(
       keys
@@ -28,7 +32,7 @@ export class ApiKeyGuard implements CanActivate {
     );
   }
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const authHeader: string | undefined = request.headers['authorization'];
 
@@ -39,14 +43,31 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     const token = authHeader.slice(7);
-    const region = this.keyToRegion.get(token);
-    if (region === undefined) {
-      throw new UnauthorizedException('Invalid API key');
+
+    // Fast path: check env var keys first
+    const envRegion = this.keyToRegion.get(token);
+    if (envRegion !== undefined) {
+      request.apiKey = token;
+      request.region = envRegion;
+      return true;
     }
 
-    // Attach the API key and region for analytics/logging
-    request.apiKey = token;
-    request.region = region;
-    return true;
+    // Slow path: check DB node keys
+    const node = await this.prisma.node.findFirst({
+      where: {
+        apiKey: token,
+        status: 'certified',
+        certificationExpiresAt: { gt: new Date() },
+      },
+    });
+
+    if (node) {
+      request.apiKey = token;
+      request.region = node.region;
+      request.nodeId = node.id;
+      return true;
+    }
+
+    throw new UnauthorizedException('Invalid API key');
   }
 }

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { PromptsController } from './prompts.controller';
 import { PromptsService } from './prompts.service';
+import { PrismaService } from '../common/prisma.service';
 
 describe('PromptsController', () => {
   let controller: PromptsController;
@@ -23,6 +24,10 @@ describe('PromptsController', () => {
         {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue('test-key') },
+        },
+        {
+          provide: PrismaService,
+          useValue: { node: { findFirst: jest.fn() } },
         },
       ],
     }).compile();

--- a/test/integration/admin/node-registry.integration.spec.ts
+++ b/test/integration/admin/node-registry.integration.spec.ts
@@ -1,0 +1,286 @@
+import { adminGet, adminPost, adminPatch, adminDelete, post } from '../utils';
+import { createTestNode, cleanupTestNodes } from '../utils/fixtures';
+
+describe('Admin Node Registry (integration)', () => {
+  afterAll(async () => {
+    await cleanupTestNodes();
+  });
+
+  describe('Register node', () => {
+    it('should register a new node with generated API key', async () => {
+      const res = await createTestNode({
+        name: `integ-register-${Date.now()}`,
+        region: 'ca',
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toBeDefined();
+      expect(res.body.apiKey).toBeDefined();
+      expect(res.body.apiKey.length).toBe(64); // 32 bytes hex
+      expect(res.body.status).toBe('pending');
+      expect(res.body.region).toBe('ca');
+    });
+
+    it('should reject duplicate node name', async () => {
+      const name = `integ-dup-${Date.now()}`;
+      const first = await createTestNode({ name });
+      expect(first.status).toBe(201);
+
+      const second = await createTestNode({ name });
+      expect(second.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it('should reject invalid name format', async () => {
+      const res = await adminPost('/admin/nodes', {
+        body: {
+          name: 'Invalid Name With Spaces!',
+          region: 'ca',
+        },
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('List nodes', () => {
+    it('should list all nodes', async () => {
+      const res = await adminGet('/admin/nodes');
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it('should filter by region', async () => {
+      const uniqueRegion = `rgn-${Date.now()}`;
+      await createTestNode({
+        name: `integ-filter-${Date.now()}`,
+        region: uniqueRegion,
+      });
+
+      const res = await adminGet(`/admin/nodes?region=${uniqueRegion}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      for (const node of res.body) {
+        expect(node.region).toBe(uniqueRegion);
+      }
+    });
+
+    it('should filter by status', async () => {
+      const res = await adminGet('/admin/nodes?status=pending');
+
+      expect(res.status).toBe(200);
+      for (const node of res.body) {
+        expect(node.status).toBe('pending');
+      }
+    });
+  });
+
+  describe('Get node by ID', () => {
+    it('should return node with audit logs', async () => {
+      const createRes = await createTestNode({
+        name: `integ-get-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+
+      const res = await adminGet(`/admin/nodes/${createRes.body.id}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(createRes.body.id);
+      expect(res.body.auditLogs).toBeDefined();
+      expect(Array.isArray(res.body.auditLogs)).toBe(true);
+      expect(res.body.auditLogs.length).toBeGreaterThanOrEqual(1);
+      expect(res.body.auditLogs[0].action).toBe('registered');
+    });
+
+    it('should return 404 for non-existent ID', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000000';
+      const res = await adminGet(`/admin/nodes/${fakeId}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('Update node', () => {
+    it('should update node metadata', async () => {
+      const createRes = await createTestNode({
+        name: `integ-update-${Date.now()}`,
+        region: 'ca',
+      });
+      expect(createRes.status).toBe(201);
+
+      const updateRes = await adminPatch(`/admin/nodes/${createRes.body.id}`, {
+        body: { region: 'tx' },
+      });
+
+      expect(updateRes.status).toBe(200);
+      expect(updateRes.body.region).toBe('tx');
+    });
+  });
+
+  describe('Certification lifecycle', () => {
+    it('should certify a pending node', async () => {
+      const createRes = await createTestNode({
+        name: `integ-certify-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+
+      const certifyRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/certify`,
+        { body: { expiresInDays: 90, reason: 'Integration test' } },
+      );
+
+      expect(certifyRes.status).toBe(201);
+      expect(certifyRes.body.status).toBe('certified');
+      expect(certifyRes.body.certifiedAt).toBeDefined();
+      expect(certifyRes.body.certificationExpiresAt).toBeDefined();
+    });
+
+    it('should allow a certified node API key to access prompt endpoints', async () => {
+      const createRes = await createTestNode({
+        name: `integ-access-${Date.now()}`,
+        region: 'ny',
+      });
+      expect(createRes.status).toBe(201);
+      const nodeApiKey = createRes.body.apiKey;
+
+      // Certify the node
+      const certifyRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/certify`,
+        { body: { expiresInDays: 30 } },
+      );
+      expect(certifyRes.status).toBe(201);
+
+      // Use the node's API key to access a prompt endpoint
+      const promptRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${nodeApiKey}` },
+        body: { context: 'Test context', query: 'Test query' },
+      });
+
+      expect(promptRes.status).toBe(201);
+      expect(promptRes.body.promptText).toBeDefined();
+    });
+
+    it('should decertify a node and revoke API access', async () => {
+      const createRes = await createTestNode({
+        name: `integ-decertify-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const nodeApiKey = createRes.body.apiKey;
+
+      // Certify
+      await adminPost(`/admin/nodes/${createRes.body.id}/certify`, {
+        body: {},
+      });
+
+      // Decertify
+      const decertifyRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/decertify`,
+        { body: { reason: 'Terms violation' } },
+      );
+      expect(decertifyRes.status).toBe(201);
+      expect(decertifyRes.body.status).toBe('decertified');
+
+      // Verify API key no longer works
+      const promptRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${nodeApiKey}` },
+        body: { context: 'Test', query: 'Test' },
+      });
+      expect(promptRes.status).toBe(401);
+    });
+
+    it('should recertify a previously decertified node', async () => {
+      const createRes = await createTestNode({
+        name: `integ-recertify-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+
+      // Certify then decertify
+      await adminPost(`/admin/nodes/${createRes.body.id}/certify`, {
+        body: {},
+      });
+      await adminPost(`/admin/nodes/${createRes.body.id}/decertify`, {
+        body: { reason: 'Temporary suspension' },
+      });
+
+      // Recertify
+      const recertifyRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/recertify`,
+        { body: { expiresInDays: 180, reason: 'Issue resolved' } },
+      );
+
+      expect(recertifyRes.status).toBe(201);
+      expect(recertifyRes.body.status).toBe('certified');
+      expect(recertifyRes.body.decertifiedAt).toBeNull();
+    });
+  });
+
+  describe('API key rotation', () => {
+    it('should generate a new API key and invalidate the old one', async () => {
+      const createRes = await createTestNode({
+        name: `integ-rotate-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const oldKey = createRes.body.apiKey;
+
+      // Certify the node
+      await adminPost(`/admin/nodes/${createRes.body.id}/certify`, {
+        body: {},
+      });
+
+      // Rotate key
+      const rotateRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/rotate-key`,
+        {},
+      );
+
+      expect(rotateRes.status).toBe(201);
+      expect(rotateRes.body.apiKey).toBeDefined();
+      expect(rotateRes.body.apiKey).not.toBe(oldKey);
+
+      // Old key should no longer work
+      const oldKeyRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${oldKey}` },
+        body: { context: 'Test', query: 'Test' },
+      });
+      expect(oldKeyRes.status).toBe(401);
+
+      // New key should work (node is still certified)
+      const newKeyRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${rotateRes.body.apiKey}` },
+        body: { context: 'Test', query: 'Test' },
+      });
+      expect(newKeyRes.status).toBe(201);
+    });
+  });
+
+  describe('Health dashboard', () => {
+    it('should return aggregated node status info', async () => {
+      const res = await adminGet('/admin/nodes/health');
+
+      expect(res.status).toBe(200);
+      expect(typeof res.body.totalNodes).toBe('number');
+      expect(res.body.byStatus).toBeDefined();
+      expect(Array.isArray(res.body.expiringIn30Days)).toBe(true);
+      expect(Array.isArray(res.body.recentlyRegistered)).toBe(true);
+    });
+  });
+
+  describe('Delete node', () => {
+    it('should delete a node', async () => {
+      const createRes = await createTestNode({
+        name: `integ-delete-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const id = createRes.body.id;
+
+      const deleteRes = await adminDelete(`/admin/nodes/${id}`);
+      expect(deleteRes.status).toBe(200);
+      expect(deleteRes.body.deleted).toBe(true);
+
+      // Verify it's gone
+      const getRes = await adminGet(`/admin/nodes/${id}`);
+      expect(getRes.status).toBe(404);
+    });
+  });
+});

--- a/test/integration/admin/node-registry.integration.spec.ts
+++ b/test/integration/admin/node-registry.integration.spec.ts
@@ -1,5 +1,13 @@
-import { adminGet, adminPost, adminPatch, adminDelete, post } from '../utils';
+import {
+  adminGet,
+  adminPost,
+  adminPatch,
+  adminDelete,
+  post,
+  get,
+} from '../utils';
 import { createTestNode, cleanupTestNodes } from '../utils/fixtures';
+import { INVALID_KEY } from '../utils/config';
 
 describe('Admin Node Registry (integration)', () => {
   afterAll(async () => {
@@ -263,6 +271,91 @@ describe('Admin Node Registry (integration)', () => {
       expect(res.body.byStatus).toBeDefined();
       expect(Array.isArray(res.body.expiringIn30Days)).toBe(true);
       expect(Array.isArray(res.body.recentlyRegistered)).toBe(true);
+    });
+  });
+
+  describe('Access control', () => {
+    it('should reject a pending node API key on prompt endpoints', async () => {
+      const createRes = await createTestNode({
+        name: `integ-pending-access-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const pendingKey = createRes.body.apiKey;
+
+      // Pending node key should not work
+      const promptRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${pendingKey}` },
+        body: { context: 'Test', query: 'Test' },
+      });
+      expect(promptRes.status).toBe(401);
+    });
+
+    it('should reject requests with invalid API key', async () => {
+      const promptRes = await post('/prompts/rag', {
+        headers: { Authorization: `Bearer ${INVALID_KEY}` },
+        body: { context: 'Test', query: 'Test' },
+      });
+      expect(promptRes.status).toBe(401);
+    });
+
+    it('should reject admin endpoints without admin key', async () => {
+      const res = await get('/admin/nodes');
+      expect(res.status).toBe(401);
+    });
+
+    it('should reject certifying a decertified node via certify (must use recertify)', async () => {
+      const createRes = await createTestNode({
+        name: `integ-certify-decert-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+
+      // Certify then decertify
+      await adminPost(`/admin/nodes/${createRes.body.id}/certify`, {
+        body: {},
+      });
+      await adminPost(`/admin/nodes/${createRes.body.id}/decertify`, {
+        body: { reason: 'Test' },
+      });
+
+      // Try to certify again (should fail — must use recertify)
+      const certifyRes = await adminPost(
+        `/admin/nodes/${createRes.body.id}/certify`,
+        { body: {} },
+      );
+      expect(certifyRes.status).toBe(400);
+    });
+  });
+
+  describe('Audit trail', () => {
+    it('should record all lifecycle events in audit log', async () => {
+      const createRes = await createTestNode({
+        name: `integ-audit-${Date.now()}`,
+      });
+      expect(createRes.status).toBe(201);
+      const nodeId = createRes.body.id;
+
+      // Certify → decertify → recertify
+      await adminPost(`/admin/nodes/${nodeId}/certify`, {
+        body: { reason: 'Initial cert' },
+      });
+      await adminPost(`/admin/nodes/${nodeId}/decertify`, {
+        body: { reason: 'Suspension' },
+      });
+      await adminPost(`/admin/nodes/${nodeId}/recertify`, {
+        body: { reason: 'Reinstated' },
+      });
+
+      const getRes = await adminGet(`/admin/nodes/${nodeId}`);
+      expect(getRes.status).toBe(200);
+
+      const actions = getRes.body.auditLogs.map(
+        (log: { action: string }) => log.action,
+      );
+      expect(actions).toContain('registered');
+      expect(actions).toContain('certified');
+      expect(actions).toContain('decertified');
+      expect(actions).toContain('recertified');
+      expect(getRes.body.auditLogs.length).toBe(4);
     });
   });
 

--- a/test/integration/utils/db-helpers.ts
+++ b/test/integration/utils/db-helpers.ts
@@ -14,6 +14,8 @@ export function getDb(): PrismaClient {
 
 export async function cleanTestData() {
   const db = getDb();
+  await db.nodeAuditLog.deleteMany({});
+  await db.node.deleteMany({});
   await db.promptRequestLog.deleteMany({});
   await db.experimentVariant.deleteMany({});
   await db.experiment.deleteMany({});

--- a/test/integration/utils/fixtures.ts
+++ b/test/integration/utils/fixtures.ts
@@ -2,6 +2,7 @@ import { adminPost, adminDelete } from './http-client';
 import { getDb } from './db-helpers';
 
 let createdTemplateIds: string[] = [];
+let createdNodeIds: string[] = [];
 
 export async function createTestTemplate(
   overrides: Record<string, unknown> = {},
@@ -36,4 +37,28 @@ export async function cleanupTestTemplates() {
     await adminDelete(`/admin/templates/${id}`).catch(() => {});
   }
   createdTemplateIds = [];
+}
+
+export async function createTestNode(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    name: `test-node-${Date.now()}`,
+    region: 'ca',
+  };
+
+  const res = await adminPost('/admin/nodes', {
+    body: { ...defaults, ...overrides },
+  });
+
+  if (res.status === 201) {
+    createdNodeIds.push(res.body.id);
+  }
+
+  return res;
+}
+
+export async function cleanupTestNodes() {
+  for (const id of createdNodeIds) {
+    await adminDelete(`/admin/nodes/${id}`).catch(() => {});
+  }
+  createdNodeIds = [];
 }


### PR DESCRIPTION
## Summary
- Adds federated node registry with full lifecycle management (register, certify, decertify, recertify, rotate key, delete)
- Extends `ApiKeyGuard` with async DB-backed node key validation — env var keys remain as fast path, certified node keys checked via DB
- Audit trail tracks all node lifecycle events with admin key prefix
- Health dashboard endpoint with status aggregation, expiry alerts, and recent registrations
- 10 new REST endpoints under `/admin/nodes` protected by `AdminKeyGuard`

## Test plan
- [x] 109 unit tests passing (24 new for node registry service + controller + updated guard)
- [x] Lint clean
- [x] Build clean
- [ ] `pnpm test:integration:docker` — run full Docker integration suite including new node registry tests
- [ ] Verify: register node → certify → node API key works on `/prompts/rag` → decertify → key rejected
- [ ] Verify health dashboard returns aggregated status info

🤖 Generated with [Claude Code](https://claude.com/claude-code)