### PR TITLE
feat: node registry, certification & SonarCloud integration (#428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +14,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -44,6 +43,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -69,8 +70,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
@@ -102,9 +101,35 @@ jobs:
           path: coverage/
           retention-days: 1
 
+  sonarcloud:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: coverage-reports
+          path: coverage-reports
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [lint, test]
     steps:
       - name: Checkout
@@ -133,6 +158,8 @@ jobs:
   integration:
     name: Integration Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [lint, test]
     timeout-minutes: 15
     steps:

--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -10,11 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+          if [[ "$HEAD_REF" != "develop" ]]; then
             echo "::error::PRs to main must come from the develop branch"
             echo ""
-            echo "Current source branch: ${{ github.head_ref }}"
+            echo "Current source branch: $HEAD_REF"
             echo ""
             echo "To fix this:"
             echo "1. Merge your changes to develop first"

--- a/Dockerfile.test-runner
+++ b/Dockerfile.test-runner
@@ -5,8 +5,7 @@ WORKDIR /app
 # Install dependencies
 COPY package.json pnpm-lock.yaml* ./
 COPY prisma ./prisma/
-RUN pnpm install --frozen-lockfile || pnpm install
-RUN pnpm db:generate
+RUN (pnpm install --frozen-lockfile || pnpm install) && pnpm db:generate
 
 # Copy source and test files
 COPY src ./src/

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
       "!**/main.ts"
     ],
     "coverageDirectory": "../coverage",
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "clover"
+    ],
     "testEnvironment": "node"
   }
 }

--- a/scripts/test-integration-docker.sh
+++ b/scripts/test-integration-docker.sh
@@ -14,6 +14,7 @@ NC='\033[0m'
 cleanup() {
   echo -e "\n${YELLOW}Cleaning up...${NC}"
   docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" down -v --remove-orphans 2>/dev/null || true
+  return 0
 }
 trap cleanup EXIT
 
@@ -29,7 +30,7 @@ for i in $(seq 1 30); do
     echo -e "${GREEN}PostgreSQL is ready${NC}"
     break
   fi
-  if [ "$i" -eq 30 ]; then
+  if [[ "$i" -eq 30 ]]; then
     echo -e "${RED}PostgreSQL failed to start${NC}"
     docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" logs prompt-db-test
     exit 1
@@ -44,7 +45,7 @@ for i in $(seq 1 60); do
     echo -e "${GREEN}Prompt service is healthy with seeded templates${NC}"
     break
   fi
-  if [ "$i" -eq 60 ]; then
+  if [[ "$i" -eq 60 ]]; then
     echo -e "${RED}Prompt service failed to become healthy${NC}"
     docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" logs prompt-service
     exit 1
@@ -56,7 +57,7 @@ echo -e "${GREEN}=== Running integration tests ===${NC}"
 docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --profile test run --rm --build test-runner
 TEST_EXIT=$?
 
-if [ $TEST_EXIT -eq 0 ]; then
+if [[ $TEST_EXIT -eq 0 ]]; then
   echo -e "\n${GREEN}=== Integration tests passed ===${NC}"
 else
   echo -e "\n${RED}=== Integration tests failed ===${NC}"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,44 @@
+# SonarCloud Configuration
+sonar.projectKey=OpusPopuli_prompt-service
+sonar.organization=opuspopuli
+
+# Project metadata
+sonar.projectName=prompt-service
+sonar.projectVersion=0.1.0
+
+# Source code locations
+sonar.sources=src
+
+# Test directories
+sonar.tests=src,test
+
+# Exclusions from source analysis
+sonar.exclusions=**/node_modules/**,**/dist/**,**/*.spec.ts,**/coverage/**,**/prisma/migrations/**
+
+# Test file patterns
+sonar.test.inclusions=**/*.spec.ts,**/test/**/*.ts
+
+# Security hotspot exclusions (test fixtures with fake credentials)
+sonar.security.exclusions=**/*.spec.ts,**/test/**/*.ts
+
+# Coverage exclusions (align with Jest coveragePathIgnorePatterns)
+# - Migrations are auto-generated database scripts
+# - main.ts is bootstrap code
+# - NestJS modules are dependency injection configuration
+# - DTOs are type definitions
+# - Seed files are one-off scripts
+sonar.coverage.exclusions=**/prisma/migrations/**,**/prisma/seed.ts,**/main.ts,**/*.module.ts,**/*.dto.ts
+
+# Coverage reports (lcov format)
+# Artifacts are downloaded to coverage-reports/, preserving directory structure
+sonar.javascript.lcov.reportPaths=coverage-reports/coverage/lcov.info
+
+# TypeScript configuration
+sonar.typescript.tsconfigPaths=tsconfig.json
+
+# Duplication exclusions
+# - Seed data has repetitive structure by design
+sonar.cpd.exclusions=**/prisma/seed.ts
+
+# Encoding
+sonar.sourceEncoding=UTF-8

--- a/src/admin/dto/update-template.dto.ts
+++ b/src/admin/dto/update-template.dto.ts
@@ -1,5 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { OmitType, PartialType } from '@nestjs/swagger';
+import { ApiProperty, OmitType, PartialType } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
 import { CreateTemplateDto } from './create-template.dto';
 

--- a/src/experiments/experiments.service.ts
+++ b/src/experiments/experiments.service.ts
@@ -73,14 +73,14 @@ export class ExperimentsService {
         return variant;
       }
     }
-    return variants[variants.length - 1];
+    return variants.at(-1)!;
   }
 
   computeBucket(apiKey: string, experimentId: string): number {
     const hash = createHash('sha256')
       .update(apiKey + ':' + experimentId)
       .digest('hex');
-    const num = parseInt(hash.slice(0, 8), 16);
+    const num = Number.parseInt(hash.slice(0, 8), 16);
     return num % 100;
   }
 }

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -147,10 +147,10 @@ export class PromptsService {
     promptHash: string,
     promptVersion: string,
   ): Promise<VerifyResult> {
-    const versionNum = parseInt(promptVersion.replace('v', ''), 10);
+    const versionNum = Number.parseInt(promptVersion.replace('v', ''), 10);
 
     const templates = await this.prisma.promptTemplate.findMany({
-      where: { version: isNaN(versionNum) ? undefined : versionNum },
+      where: { version: Number.isNaN(versionNum) ? undefined : versionNum },
     });
 
     for (const t of templates) {


### PR DESCRIPTION
## Summary
- **Node Registry & Certification** (Issue #428): Full node lifecycle management — register, certify, decertify, recertify, API key rotation, delete — with audit trail and health dashboard
- **ApiKeyGuard upgrade**: Extended from sync to async with dual-source validation (env var fast path + DB-backed certified node keys)
- **SonarCloud integration**: Separate CI job with coverage reporting, plus fixes for all security/code quality findings
- **Test coverage**: 128 unit tests across 11 suites + comprehensive integration tests

## Changes
- Add `Node` + `NodeAuditLog` Prisma models with migration
- Add `NodeRegistryService` (10 lifecycle operations) and `NodeRegistryController` (10 REST endpoints)
- Add 5 DTOs: create-node, update-node, list-nodes-query, certify-node, decertify-node
- Extend `ApiKeyGuard` to validate DB-backed node API keys (certified + non-expired)
- Add `sonar-project.properties` and SonarCloud CI job with coverage artifact download
- Fix CI security issues: command injection in validate-main-pr.yml, workflow permissions scoping
- Fix code smells: `Number.parseInt`/`Number.isNaN`, bash `[[` conditionals, merged imports/RUN instructions

## Test plan
- [x] 128 unit tests passing (service, controller, guard, all edge cases)
- [x] Integration tests cover full lifecycle: register → certify → use key → decertify → key rejected
- [x] Integration tests cover: key rotation, audit trail, access control, health dashboard
- [x] Lint clean, build clean
- [ ] SonarCloud analysis passes with coverage (requires `SONAR_TOKEN` secret)
- [ ] Integration tests pass in Docker CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)