### PR TITLE
fix: correct SonarCloud coverage report path

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,8 +30,8 @@ sonar.security.exclusions=**/*.spec.ts,**/test/**/*.ts
 sonar.coverage.exclusions=**/prisma/migrations/**,**/prisma/seed.ts,**/main.ts,**/*.module.ts,**/*.dto.ts
 
 # Coverage reports (lcov format)
-# Artifacts are downloaded to coverage-reports/, preserving directory structure
-sonar.javascript.lcov.reportPaths=coverage-reports/coverage/lcov.info
+# upload-artifact uploads contents of coverage/, download-artifact extracts to coverage-reports/
+sonar.javascript.lcov.reportPaths=coverage-reports/lcov.info
 
 # TypeScript configuration
 sonar.typescript.tsconfigPaths=tsconfig.json


### PR DESCRIPTION
## Summary
- Fix lcov.info path in sonar-project.properties — `upload-artifact` uploads contents of `coverage/`, so the file lands at `coverage-reports/lcov.info` not `coverage-reports/coverage/lcov.info`

## Test plan
- [ ] SonarCloud quality gate passes with coverage > 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)