### PR TITLE
chore: rename Docker services to opuspopuli-prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Show service logs on failure
         if: failure()
-        run: docker compose -f docker-compose-integration.yml logs prompt-service prompt-db-test
+        run: docker compose -f docker-compose-integration.yml logs opuspopuli-prompts opuspopuli-prompts-db-test
 
       - name: Cleanup
         if: always()

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -1,6 +1,7 @@
 services:
-  prompt-db-test:
+  opuspopuli-prompts-db-test:
     image: postgres:17-alpine
+    container_name: opuspopuli-prompts-db-test
     environment:
       POSTGRES_DB: prompt_service_test
       POSTGRES_USER: postgres
@@ -15,16 +16,18 @@ services:
 
   opuspopuli-prompts:
     build: .
+    image: opuspopuli-prompts
+    container_name: opuspopuli-prompts-test
     ports:
       - '3101:3100'
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@prompt-db-test:5432/prompt_service_test?schema=public
+      DATABASE_URL: postgresql://postgres:postgres@opuspopuli-prompts-db-test:5432/prompt_service_test?schema=public
       API_KEYS: ca:test-api-key-1,tx:test-api-key-2
       ADMIN_API_KEYS: admin-test-key-1
       PROMPT_TTL_SECONDS: 300
       PORT: 3100
     depends_on:
-      prompt-db-test:
+      opuspopuli-prompts-db-test:
         condition: service_healthy
     healthcheck:
       test: ['CMD', 'node', '-e', "require('http').get('http://localhost:3100/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
@@ -37,9 +40,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test-runner
+    container_name: opuspopuli-prompts-test-runner
     environment:
       PROMPT_SERVICE_URL: http://opuspopuli-prompts:3100
-      DATABASE_URL: postgresql://postgres:postgres@prompt-db-test:5432/prompt_service_test?schema=public
+      DATABASE_URL: postgresql://postgres:postgres@opuspopuli-prompts-db-test:5432/prompt_service_test?schema=public
       API_KEY: test-api-key-1
       API_KEY_2: test-api-key-2
       ADMIN_API_KEY: admin-test-key-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
-  prompt-db:
+  opuspopuli-prompts-db:
     image: postgres:17-alpine
+    container_name: opuspopuli-prompts-db
     environment:
       POSTGRES_DB: prompt_service
       POSTGRES_USER: postgres
@@ -8,7 +9,7 @@ services:
     ports:
       - '5433:5432'
     volumes:
-      - prompt-db-data:/var/lib/postgresql/data
+      - opuspopuli-prompts-db-data:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s
@@ -17,17 +18,20 @@ services:
 
   opuspopuli-prompts:
     build: .
+    image: opuspopuli-prompts
+    container_name: opuspopuli-prompts
     ports:
       - '3100:3100'
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@prompt-db:5432/prompt_service?schema=public
+      DATABASE_URL: postgresql://postgres:postgres@opuspopuli-prompts-db:5432/prompt_service?schema=public
       API_KEYS: dev-key-1,dev-key-2
       ADMIN_API_KEYS: admin-dev-key-1
       PROMPT_TTL_SECONDS: 3600
       PORT: 3100
     depends_on:
-      prompt-db:
+      opuspopuli-prompts-db:
         condition: service_healthy
 
 volumes:
-  prompt-db-data:
+  opuspopuli-prompts-db-data:
+    name: opuspopuli-prompts-db-data

--- a/scripts/test-integration-docker.sh
+++ b/scripts/test-integration-docker.sh
@@ -26,13 +26,13 @@ docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" up -d
 
 echo -e "${YELLOW}Waiting for PostgreSQL...${NC}"
 for i in $(seq 1 30); do
-  if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" exec -T prompt-db-test pg_isready -U postgres >/dev/null 2>&1; then
+  if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" exec -T opuspopuli-prompts-db-test pg_isready -U postgres >/dev/null 2>&1; then
     echo -e "${GREEN}PostgreSQL is ready${NC}"
     break
   fi
   if [[ "$i" -eq 30 ]]; then
     echo -e "${RED}PostgreSQL failed to start${NC}"
-    docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" logs prompt-db-test
+    docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" logs opuspopuli-prompts-db-test
     exit 1
   fi
   sleep 2


### PR DESCRIPTION
## Summary
- Rename db service from `prompt-db` to `opuspopuli-prompts-db`
- Add explicit `container_name` and `image` to avoid directory name prefix
- Add explicit volume name to prevent `prompt-service_` prefix
- Update CI workflow and integration test script with new service names

## Test plan
- [x] `docker compose up -d` starts with correct container/image/volume names
- [x] Postman tests pass against running service
- [ ] CI pipeline passes (lint, test, build, integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)