### PR TITLE
feat: add HMAC request signing for node authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ curl -X POST http://localhost:3200/prompts/document-analysis \
 
 ## API Endpoints
 
-### Prompt Serving (Node API Key)
+### Prompt Serving (Node API Key or HMAC)
+
+Prompt endpoints support **Bearer token** auth (region/env var keys) and **HMAC request signing** (registered nodes). HMAC is recommended for federated nodes — the API key never leaves the node, and requests include replay protection and tamper detection. See [API Reference](docs/api-reference.md#hmac-request-signing-recommended-for-nodes) for details.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -168,9 +170,10 @@ prompt-service/
 │   └── seed.ts                # Seeds all 13 prompt templates
 ├── src/
 │   ├── auth/
-│   │   ├── api-key.guard.ts   # Node API key validation (env + DB node keys)
+│   │   ├── api-key.guard.ts   # Node auth: Bearer tokens + HMAC request signing
 │   │   └── admin-key.guard.ts # Admin API key validation
 │   ├── common/
+│   │   ├── crypto.utils.ts    # Constant-time comparison, string helpers
 │   │   ├── prisma.module.ts   # Global Prisma provider
 │   │   └── prisma.service.ts  # Prisma client lifecycle
 │   ├── health/

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,21 +6,91 @@ Interactive Swagger UI available at `/api`.
 
 ## Authentication
 
-All prompt endpoints require a Bearer token:
+Prompt endpoints support two authentication methods: **Bearer tokens** and **HMAC request signing**.
+
+### Bearer Token Authentication
+
+Region keys and environment variable keys use a simple Bearer token:
 
 ```
 Authorization: Bearer <API_KEY>
 ```
 
-API keys are configured via the `API_KEYS` environment variable (comma-separated). An invalid or missing token returns:
+API keys are configured via the `API_KEYS` environment variable (comma-separated `region:key` pairs).
 
-```json
-{
-  "statusCode": 401,
-  "message": "Missing or invalid Authorization header",
-  "error": "Unauthorized"
-}
+### HMAC Request Signing (Recommended for Nodes)
+
+Registered nodes should use HMAC request signing. Unlike Bearer tokens, the API key never leaves the node — each request is signed with a timestamp and body hash, providing:
+
+- **Replay protection**: Requests expire after 5 minutes
+- **Tamper detection**: Body modifications invalidate the signature
+- **Key secrecy**: The shared secret is never transmitted over the wire
+
+#### HMAC Headers
+
+| Header | Description |
+|--------|-------------|
+| `X-HMAC-Signature` | Base64-encoded HMAC-SHA256 signature |
+| `X-HMAC-Timestamp` | Unix timestamp in seconds |
+| `X-HMAC-Key-Id` | Node UUID (used to look up the shared secret) |
+
+#### Signature Construction
+
 ```
+signatureString = "${timestamp}\n${method}\n${path}\n${bodyHash}"
+```
+
+Where:
+- `timestamp`: Same value as `X-HMAC-Timestamp`
+- `method`: Uppercase HTTP method (e.g., `POST`)
+- `path`: Request path (e.g., `/prompts/rag`)
+- `bodyHash`: SHA-256 hex digest of the raw request body (empty string hash for no body)
+
+The signature is computed as:
+```
+HMAC-SHA256(apiKey, signatureString) → Base64
+```
+
+#### Example (Node.js)
+
+```typescript
+import { createHash, createHmac } from 'node:crypto';
+
+const timestamp = Math.floor(Date.now() / 1000).toString();
+const method = 'POST';
+const path = '/prompts/rag';
+const body = JSON.stringify({ context: '...', query: '...' });
+
+const bodyHash = createHash('sha256').update(body).digest('hex');
+const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+const signature = createHmac('sha256', apiKey)
+  .update(signatureString)
+  .digest('base64');
+
+// Send with headers:
+// X-HMAC-Signature: <signature>
+// X-HMAC-Timestamp: <timestamp>
+// X-HMAC-Key-Id: <nodeId>
+```
+
+#### Validation Rules
+
+- Timestamp must be within ±5 minutes of server time
+- Signature uses constant-time comparison (timing-attack safe)
+- Node must be certified and not expired
+- API key is retrieved from Vault using the node's `apiKeySecretId`
+
+#### Error Responses
+
+| Message | Cause |
+|---------|-------|
+| `Missing HMAC headers` | Signature header present but timestamp or key-id missing |
+| `Invalid HMAC timestamp` | Timestamp is not a valid number |
+| `HMAC timestamp expired` | Timestamp outside ±5 minute window |
+| `Unknown node` | Node UUID not found in database |
+| `Node is not certified` | Node is pending, decertified, or certification expired |
+| `Failed to retrieve node key` | Vault lookup failed |
+| `Invalid HMAC signature` | Signature mismatch (wrong key, tampered body, etc.) |
 
 ### Admin Authentication
 

--- a/postman/prompt-service.postman_collection.json
+++ b/postman/prompt-service.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Opus Populi - Prompt Service",
-    "description": "API collection for the Opus Populi private AI prompt service.\n\n## Authentication\n- **Node endpoints** (`/prompts/*`): Use `{{apiKey}}` (format: `region:key`)\n- **Admin endpoints** (`/admin/*`): Use `{{adminKey}}`\n\n## Setup\n1. Import this collection\n2. Import the environment file (`prompt-service.postman_environment.json`)\n3. Start the service: `docker compose up -d`\n4. Run the Health Check request first to verify connectivity",
+    "description": "API collection for the Opus Populi private AI prompt service.\n\n## Authentication\n- **Bearer token** (`/prompts/*`): Use `{{apiKey}}` (format: `region:key`) — region keys and env var keys\n- **HMAC signing** (`/prompts/*`): Use `{{nodeApiKey}}` + `{{nodeId}}` — registered node keys with request signing\n- **Admin endpoints** (`/admin/*`): Use `{{adminKey}}`\n\n## HMAC Setup\n1. Register a node: Run **Admin - Node Registry > Register Node** (saves `nodeId` and `nodeApiKey`)\n2. Certify the node: Run **Admin - Node Registry > Certify Node**\n3. Use requests in the **HMAC Auth** folder — pre-request scripts compute signatures automatically\n\n## Setup\n1. Import this collection\n2. Import the environment file (`prompt-service.postman_environment.json`)\n3. Start the service: `docker compose up -d`\n4. Run the Health Check request first to verify connectivity",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -11,7 +11,8 @@
     { "key": "templateId", "value": "" },
     { "key": "experimentId", "value": "" },
     { "key": "nodeId", "value": "" },
-    { "key": "versionId", "value": "" }
+    { "key": "versionId", "value": "" },
+    { "key": "nodeApiKey", "value": "" }
   ],
   "item": [
     {
@@ -485,6 +486,11 @@
                   "  pm.expect(body).to.have.property('id');",
                   "  pm.expect(body).to.have.property('apiKey');",
                   "  pm.collectionVariables.set('nodeId', body.id);",
+                  "  pm.collectionVariables.set('nodeApiKey', body.apiKey);",
+                  "  pm.environment.set('nodeId', body.id);",
+                  "  pm.environment.set('nodeApiKey', body.apiKey);",
+                  "  console.log('Saved nodeId: ' + body.id);",
+                  "  console.log('Saved nodeApiKey: ' + body.apiKey.substring(0, 8) + '...');",
                   "});"
                 ]
               }
@@ -569,6 +575,14 @@
                   "pm.test('Has audit logs', () => {",
                   "  const body = pm.response.json();",
                   "  pm.expect(body).to.have.property('auditLogs');",
+                  "  if (body.id) {",
+                  "    pm.collectionVariables.set('nodeId', body.id);",
+                  "    pm.environment.set('nodeId', body.id);",
+                  "  }",
+                  "  if (body.apiKey) {",
+                  "    pm.collectionVariables.set('nodeApiKey', body.apiKey);",
+                  "    pm.environment.set('nodeApiKey', body.apiKey);",
+                  "  }",
                   "});"
                 ]
               }
@@ -616,7 +630,17 @@
                 "exec": [
                   "pm.test('Status is 200', () => pm.response.to.have.status(200));",
                   "pm.test('Node certified', () => {",
-                  "  pm.expect(pm.response.json().status).to.eql('certified');",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.status).to.eql('certified');",
+                  "  if (body.id) {",
+                  "    pm.collectionVariables.set('nodeId', body.id);",
+                  "    pm.environment.set('nodeId', body.id);",
+                  "  }",
+                  "  if (body.apiKey) {",
+                  "    pm.collectionVariables.set('nodeApiKey', body.apiKey);",
+                  "    pm.environment.set('nodeApiKey', body.apiKey);",
+                  "  }",
+                  "  console.log('Saved nodeId:', body.id, 'nodeApiKey:', body.apiKey ? '***' : 'NOT FOUND');",
                   "});"
                 ]
               }
@@ -672,7 +696,16 @@
                 "exec": [
                   "pm.test('Status is 200', () => pm.response.to.have.status(200));",
                   "pm.test('Node recertified', () => {",
-                  "  pm.expect(pm.response.json().status).to.eql('certified');",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.status).to.eql('certified');",
+                  "  if (body.id) {",
+                  "    pm.collectionVariables.set('nodeId', body.id);",
+                  "    pm.environment.set('nodeId', body.id);",
+                  "  }",
+                  "  if (body.apiKey) {",
+                  "    pm.collectionVariables.set('nodeApiKey', body.apiKey);",
+                  "    pm.environment.set('nodeApiKey', body.apiKey);",
+                  "  }",
                   "});"
                 ]
               }
@@ -702,6 +735,10 @@
                   "pm.test('New API key returned', () => {",
                   "  const body = pm.response.json();",
                   "  pm.expect(body).to.have.property('apiKey');",
+                  "  if (body.apiKey) {",
+                  "    pm.collectionVariables.set('nodeApiKey', body.apiKey);",
+                  "    pm.environment.set('nodeApiKey', body.apiKey);",
+                  "  }",
                   "});"
                 ]
               }
@@ -733,6 +770,188 @@
               { "key": "Authorization", "value": "Bearer {{adminKey}}" }
             ],
             "url": { "raw": "{{baseUrl}}/admin/nodes/{{nodeId}}", "host": ["{{baseUrl}}"], "path": ["admin", "nodes", "{{nodeId}}"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "HMAC Auth",
+      "description": "Prompt endpoints using HMAC request signing instead of Bearer tokens.\n\n## Setup\n1. Register a node via **Admin - Node Registry > Register Node** (saves `nodeId` and `nodeApiKey`)\n2. Certify the node via **Admin - Node Registry > Certify Node** (also saves `nodeId` and `nodeApiKey`)\n3. Run requests in this folder — the pre-request script computes the HMAC signature automatically\n\n**Note:** If the node is already registered, skip step 1. The Certify, Re-certify, Get Node by ID, and Rotate Key endpoints all save `nodeId` and `nodeApiKey` to your environment.\n\n## How it works\nEach request is signed with:\n- `X-HMAC-Signature`: HMAC-SHA256(apiKey, `timestamp\\nmethod\\npath\\nbodyHash`) → Base64\n- `X-HMAC-Timestamp`: Unix timestamp (seconds)\n- `X-HMAC-Key-Id`: Node UUID",
+      "item": [
+        {
+          "name": "RAG (HMAC)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const apiKey = pm.collectionVariables.get('nodeApiKey') || pm.environment.get('nodeApiKey') || pm.variables.get('nodeApiKey');",
+                  "const nodeId = pm.collectionVariables.get('nodeId') || pm.environment.get('nodeId') || pm.variables.get('nodeId');",
+                  "",
+                  "if (!apiKey || !nodeId) {",
+                  "  throw new Error('nodeApiKey or nodeId not set. Run Register Node + Certify Node first.');",
+                  "}",
+                  "",
+                  "const timestamp = Math.floor(Date.now() / 1000).toString();",
+                  "const method = pm.request.method;",
+                  "const path = '/' + pm.request.url.path.join('/');",
+                  "const body = pm.request.body ? pm.request.body.raw : '';",
+                  "const bodyHash = CryptoJS.SHA256(body).toString();",
+                  "const signatureString = timestamp + '\\n' + method + '\\n' + path + '\\n' + bodyHash;",
+                  "const signature = CryptoJS.HmacSHA256(signatureString, apiKey).toString(CryptoJS.enc.Base64);",
+                  "",
+                  "console.log('HMAC Debug - path:', path, 'method:', method, 'keyPrefix:', apiKey.substring(0, 8));",
+                  "console.log('HMAC Debug - bodyHash:', bodyHash);",
+                  "console.log('HMAC Debug - signature:', signature);",
+                  "",
+                  "pm.request.headers.add({ key: 'X-HMAC-Signature', value: signature });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Timestamp', value: timestamp });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Key-Id', value: nodeId });"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "  pm.expect(body).to.have.property('promptVersion');",
+                  "  pm.expect(body).to.have.property('expiresAt');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"context\": \"Proposition 36 amends the California Constitution to increase penalties for certain drug and theft crimes.\",\n  \"query\": \"What does Proposition 36 change about drug crime penalties?\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/prompts/rag", "host": ["{{baseUrl}}"], "path": ["prompts", "rag"] }
+          }
+        },
+        {
+          "name": "Structural Analysis (HMAC)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const apiKey = pm.collectionVariables.get('nodeApiKey') || pm.environment.get('nodeApiKey') || pm.variables.get('nodeApiKey');",
+                  "const nodeId = pm.collectionVariables.get('nodeId') || pm.environment.get('nodeId') || pm.variables.get('nodeId');",
+                  "",
+                  "if (!apiKey || !nodeId) {",
+                  "  throw new Error('nodeApiKey or nodeId not set. Run Register Node + Certify Node first.');",
+                  "}",
+                  "",
+                  "const timestamp = Math.floor(Date.now() / 1000).toString();",
+                  "const method = pm.request.method;",
+                  "const path = '/' + pm.request.url.path.join('/');",
+                  "const body = pm.request.body ? pm.request.body.raw : '';",
+                  "const bodyHash = CryptoJS.SHA256(body).toString();",
+                  "const signatureString = timestamp + '\\n' + method + '\\n' + path + '\\n' + bodyHash;",
+                  "const signature = CryptoJS.HmacSHA256(signatureString, apiKey).toString(CryptoJS.enc.Base64);",
+                  "",
+                  "console.log('HMAC Debug - path:', path, 'method:', method, 'keyPrefix:', apiKey.substring(0, 8));",
+                  "console.log('HMAC Debug - bodyHash:', bodyHash);",
+                  "console.log('HMAC Debug - signature:', signature);",
+                  "",
+                  "pm.request.headers.add({ key: 'X-HMAC-Signature', value: signature });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Timestamp', value: timestamp });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Key-Id', value: nodeId });"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"dataType\": \"propositions\",\n  \"contentGoal\": \"Extract ballot measure details\",\n  \"category\": \"political\",\n  \"hints\": [\"Look for Proposition in headings\"],\n  \"html\": \"<html><body><h1>Proposition 1</h1><p>This measure would authorize bonds...</p></body></html>\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/prompts/structural-analysis", "host": ["{{baseUrl}}"], "path": ["prompts", "structural-analysis"] }
+          }
+        },
+        {
+          "name": "Document Analysis (HMAC)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const apiKey = pm.collectionVariables.get('nodeApiKey') || pm.environment.get('nodeApiKey') || pm.variables.get('nodeApiKey');",
+                  "const nodeId = pm.collectionVariables.get('nodeId') || pm.environment.get('nodeId') || pm.variables.get('nodeId');",
+                  "",
+                  "if (!apiKey || !nodeId) {",
+                  "  throw new Error('nodeApiKey or nodeId not set. Run Register Node + Certify Node first.');",
+                  "}",
+                  "",
+                  "const timestamp = Math.floor(Date.now() / 1000).toString();",
+                  "const method = pm.request.method;",
+                  "const path = '/' + pm.request.url.path.join('/');",
+                  "const body = pm.request.body ? pm.request.body.raw : '';",
+                  "const bodyHash = CryptoJS.SHA256(body).toString();",
+                  "const signatureString = timestamp + '\\n' + method + '\\n' + path + '\\n' + bodyHash;",
+                  "const signature = CryptoJS.HmacSHA256(signatureString, apiKey).toString(CryptoJS.enc.Base64);",
+                  "",
+                  "console.log('HMAC Debug - path:', path, 'method:', method, 'keyPrefix:', apiKey.substring(0, 8));",
+                  "console.log('HMAC Debug - bodyHash:', bodyHash);",
+                  "console.log('HMAC Debug - signature:', signature);",
+                  "",
+                  "pm.request.headers.add({ key: 'X-HMAC-Signature', value: signature });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Timestamp', value: timestamp });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Key-Id', value: nodeId });"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"documentType\": \"petition\",\n  \"text\": \"We, the undersigned residents of California, hereby petition the state legislature to allocate additional funding for public transit.\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/prompts/document-analysis", "host": ["{{baseUrl}}"], "path": ["prompts", "document-analysis"] }
           }
         }
       ]

--- a/postman/prompt-service.postman_environment.json
+++ b/postman/prompt-service.postman_environment.json
@@ -43,6 +43,12 @@
       "value": "",
       "type": "default",
       "enabled": true
+    },
+    {
+      "key": "nodeApiKey",
+      "value": "",
+      "type": "secret",
+      "enabled": true
     }
   ],
   "_postman_variable_scope": "environment"

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -1,12 +1,13 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createHash } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { ApiKeyGuard } from './api-key.guard';
 
 function createMockPrisma() {
   return {
     node: {
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
     },
   };
 }
@@ -14,14 +15,17 @@ function createMockPrisma() {
 function createMockVault() {
   return {
     getSecretsByPrefix: jest.fn().mockResolvedValue([]),
+    getSecret: jest.fn(),
     createSecret: jest.fn(),
     deleteSecret: jest.fn(),
   };
 }
 
-function createMockContext(authHeader?: string) {
+function createMockContext(headers: Record<string, string> = {}) {
   const request: Record<string, unknown> = {
-    headers: authHeader ? { authorization: authHeader } : {},
+    headers,
+    method: 'POST',
+    path: '/prompts/rag',
   };
 
   return {
@@ -30,6 +34,46 @@ function createMockContext(authHeader?: string) {
     } as unknown as ExecutionContext,
     request,
   };
+}
+
+function createBearerContext(authHeader?: string) {
+  return createMockContext(authHeader ? { authorization: authHeader } : {});
+}
+
+/** Helper to compute an HMAC signature for tests. */
+function computeHmac(
+  apiKey: string,
+  timestamp: string,
+  method: string,
+  path: string,
+  body: string,
+): string {
+  const bodyHash = createHash('sha256').update(body).digest('hex');
+  const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+  return createHmac('sha256', apiKey).update(signatureString).digest('base64');
+}
+
+function createHmacContext(
+  apiKey: string,
+  nodeId: string,
+  body: string = '{"context":"test","query":"test"}',
+  timestampOverride?: string,
+) {
+  const timestamp =
+    timestampOverride ?? Math.floor(Date.now() / 1000).toString();
+  const method = 'POST';
+  const path = '/prompts/rag';
+  const signature = computeHmac(apiKey, timestamp, method, path, body);
+
+  const { ctx, request } = createMockContext({
+    'x-hmac-signature': signature,
+    'x-hmac-timestamp': timestamp,
+    'x-hmac-key-id': nodeId,
+    'content-type': 'application/json',
+  });
+
+  request.rawBody = Buffer.from(body);
+  return { ctx, request };
 }
 
 describe('ApiKeyGuard', () => {
@@ -51,28 +95,28 @@ describe('ApiKeyGuard', () => {
   });
 
   it('should allow a valid env var API key', async () => {
-    const { ctx } = createMockContext('Bearer key-1');
+    const { ctx } = createBearerContext('Bearer key-1');
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
   it('should reject missing Authorization header', async () => {
-    const { ctx } = createMockContext();
+    const { ctx } = createBearerContext();
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
   it('should reject non-Bearer auth', async () => {
-    const { ctx } = createMockContext('Basic abc123');
+    const { ctx } = createBearerContext('Basic abc123');
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
   it('should reject invalid API key not in env or DB', async () => {
     mockPrisma.node.findFirst.mockResolvedValue(null);
-    const { ctx } = createMockContext('Bearer invalid-key');
+    const { ctx } = createBearerContext('Bearer invalid-key');
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
   it('should attach apiKey and region to request for env var keys', async () => {
-    const { ctx, request } = createMockContext('Bearer key-2');
+    const { ctx, request } = createBearerContext('Bearer key-2');
 
     await guard.canActivate(ctx);
 
@@ -83,7 +127,7 @@ describe('ApiKeyGuard', () => {
 
   it('should reject Bearer token with no key after space', async () => {
     mockPrisma.node.findFirst.mockResolvedValue(null);
-    const { ctx } = createMockContext('Bearer ');
+    const { ctx } = createBearerContext('Bearer ');
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
@@ -97,8 +141,7 @@ describe('ApiKeyGuard', () => {
       createMockVault() as never,
     );
 
-    const { ctx } = createMockContext('Bearer some-key');
-    // Should fall through to DB lookup since no env keys configured
+    const { ctx } = createBearerContext('Bearer some-key');
     await expect(emptyGuard.canActivate(ctx)).rejects.toThrow(
       UnauthorizedException,
     );
@@ -114,7 +157,7 @@ describe('ApiKeyGuard', () => {
       createMockVault() as never,
     );
 
-    const { ctx, request } = createMockContext('Bearer key:with:colons');
+    const { ctx, request } = createBearerContext('Bearer key:with:colons');
     await colonGuard.canActivate(ctx);
 
     expect(request.apiKey).toBe('key:with:colons');
@@ -131,7 +174,7 @@ describe('ApiKeyGuard', () => {
       createMockVault() as never,
     );
 
-    const { ctx, request } = createMockContext('Bearer legacy-key');
+    const { ctx, request } = createBearerContext('Bearer legacy-key');
 
     await legacyGuard.canActivate(ctx);
 
@@ -150,7 +193,7 @@ describe('ApiKeyGuard', () => {
         apiKeyHash: nodeKeyHash,
         status: 'certified',
       });
-      const { ctx, request } = createMockContext(`Bearer ${nodeKey}`);
+      const { ctx, request } = createBearerContext(`Bearer ${nodeKey}`);
 
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(request.apiKey).toBe(nodeKey);
@@ -160,7 +203,7 @@ describe('ApiKeyGuard', () => {
 
     it('should query DB with hashed token', async () => {
       mockPrisma.node.findFirst.mockResolvedValue(null);
-      const { ctx } = createMockContext('Bearer some-node-key');
+      const { ctx } = createBearerContext('Bearer some-node-key');
 
       await guard.canActivate(ctx).catch(() => {});
 
@@ -177,7 +220,7 @@ describe('ApiKeyGuard', () => {
     });
 
     it('should query DB only when key not found in env vars', async () => {
-      const { ctx } = createMockContext('Bearer key-1');
+      const { ctx } = createBearerContext('Bearer key-1');
 
       await guard.canActivate(ctx);
 
@@ -186,7 +229,7 @@ describe('ApiKeyGuard', () => {
 
     it('should reject when node is not certified', async () => {
       mockPrisma.node.findFirst.mockResolvedValue(null);
-      const { ctx } = createMockContext('Bearer uncertified-node-key');
+      const { ctx } = createBearerContext('Bearer uncertified-node-key');
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(
         UnauthorizedException,
@@ -195,7 +238,7 @@ describe('ApiKeyGuard', () => {
 
     it('should reject expired node certification (DB returns null for expired)', async () => {
       mockPrisma.node.findFirst.mockResolvedValue(null);
-      const { ctx } = createMockContext('Bearer expired-node-key');
+      const { ctx } = createBearerContext('Bearer expired-node-key');
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(
         UnauthorizedException,
@@ -204,7 +247,7 @@ describe('ApiKeyGuard', () => {
 
     it('should reject pending node key (DB returns null for non-certified)', async () => {
       mockPrisma.node.findFirst.mockResolvedValue(null);
-      const { ctx } = createMockContext('Bearer pending-node-key');
+      const { ctx } = createBearerContext('Bearer pending-node-key');
 
       await expect(guard.canActivate(ctx)).rejects.toThrow(
         UnauthorizedException,
@@ -212,7 +255,7 @@ describe('ApiKeyGuard', () => {
     });
 
     it('should not set nodeId for env var keys', async () => {
-      const { ctx, request } = createMockContext('Bearer key-3');
+      const { ctx, request } = createBearerContext('Bearer key-3');
 
       await guard.canActivate(ctx);
 
@@ -230,7 +273,7 @@ describe('ApiKeyGuard', () => {
 
       await guard.onModuleInit();
 
-      const { ctx, request } = createMockContext('Bearer vault-fl-key');
+      const { ctx, request } = createBearerContext('Bearer vault-fl-key');
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(request.region).toBe('fl');
     });
@@ -242,8 +285,7 @@ describe('ApiKeyGuard', () => {
 
       await guard.onModuleInit();
 
-      // Env var keys should still work
-      const { ctx } = createMockContext('Bearer key-1');
+      const { ctx } = createBearerContext('Bearer key-1');
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
     });
 
@@ -254,13 +296,177 @@ describe('ApiKeyGuard', () => {
 
       await guard.onModuleInit();
 
-      // Env var key still works
-      const { ctx: ctx1 } = createMockContext('Bearer key-1');
+      const { ctx: ctx1 } = createBearerContext('Bearer key-1');
       await expect(guard.canActivate(ctx1)).resolves.toBe(true);
 
-      // Vault key also works
-      const { ctx: ctx2 } = createMockContext('Bearer vault-fl-key');
+      const { ctx: ctx2 } = createBearerContext('Bearer vault-fl-key');
       await expect(guard.canActivate(ctx2)).resolves.toBe(true);
+    });
+  });
+
+  describe('HMAC authentication', () => {
+    const nodeId = 'hmac-node-uuid';
+    const apiKey = 'test-hmac-api-key-64chars-hex-padded-to-reach-length';
+    const certifiedNode = {
+      id: nodeId,
+      region: 'ca',
+      status: 'certified',
+      apiKeySecretId: 'vault-secret-uuid',
+      certificationExpiresAt: new Date(Date.now() + 86400000), // +1 day
+    };
+
+    it('should authenticate with valid HMAC signature', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+      mockVault.getSecret.mockResolvedValue(apiKey);
+
+      const { ctx, request } = createHmacContext(apiKey, nodeId);
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(request.region).toBe('ca');
+      expect(request.nodeId).toBe(nodeId);
+    });
+
+    it('should reject expired timestamp (past)', async () => {
+      const expiredTimestamp = (Math.floor(Date.now() / 1000) - 600).toString(); // 10 min ago
+      const { ctx } = createHmacContext(
+        apiKey,
+        nodeId,
+        '{"test":"body"}',
+        expiredTimestamp,
+      );
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'HMAC timestamp expired',
+      );
+    });
+
+    it('should reject future timestamp beyond window', async () => {
+      const futureTimestamp = (Math.floor(Date.now() / 1000) + 600).toString(); // 10 min ahead
+      const { ctx } = createHmacContext(
+        apiKey,
+        nodeId,
+        '{"test":"body"}',
+        futureTimestamp,
+      );
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'HMAC timestamp expired',
+      );
+    });
+
+    it('should reject invalid signature', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+      mockVault.getSecret.mockResolvedValue(apiKey);
+
+      const { ctx, request } = createHmacContext(apiKey, nodeId);
+      // Tamper with the signature
+      request.headers = {
+        ...(request.headers as Record<string, string>),
+        'x-hmac-signature': 'dGFtcGVyZWQgc2lnbmF0dXJl',
+      };
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Invalid HMAC signature',
+      );
+    });
+
+    it('should reject when body is tampered after signing', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+      mockVault.getSecret.mockResolvedValue(apiKey);
+
+      const originalBody = '{"context":"original","query":"test"}';
+      const { ctx, request } = createHmacContext(apiKey, nodeId, originalBody);
+      // Tamper with the body after signing
+      request.rawBody = Buffer.from('{"context":"tampered","query":"test"}');
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Invalid HMAC signature',
+      );
+    });
+
+    it('should reject unknown node ID', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(null);
+
+      const { ctx } = createHmacContext(apiKey, 'non-existent-node');
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Unknown node');
+    });
+
+    it('should reject decertified node', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue({
+        ...certifiedNode,
+        status: 'decertified',
+      });
+
+      const { ctx } = createHmacContext(apiKey, nodeId);
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Node is not certified',
+      );
+    });
+
+    it('should reject node with expired certification', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue({
+        ...certifiedNode,
+        certificationExpiresAt: new Date(Date.now() - 86400000), // expired
+      });
+
+      const { ctx } = createHmacContext(apiKey, nodeId);
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Node is not certified',
+      );
+    });
+
+    it('should reject when Vault key retrieval fails', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+      mockVault.getSecret.mockRejectedValue(new Error('Vault error'));
+
+      const { ctx } = createHmacContext(apiKey, nodeId);
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Failed to retrieve node key',
+      );
+    });
+
+    it('should reject missing HMAC headers', async () => {
+      // Has signature but missing timestamp and key-id
+      const { ctx } = createMockContext({
+        'x-hmac-signature': 'some-sig',
+      });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Missing HMAC headers',
+      );
+    });
+
+    it('should reject invalid (non-numeric) timestamp', async () => {
+      const { ctx } = createMockContext({
+        'x-hmac-signature': 'some-sig',
+        'x-hmac-timestamp': 'not-a-number',
+        'x-hmac-key-id': nodeId,
+      });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        'Invalid HMAC timestamp',
+      );
+    });
+
+    it('should fall through to Bearer when no HMAC headers present', async () => {
+      const { ctx } = createBearerContext('Bearer key-1');
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(mockPrisma.node.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty body (GET-like requests)', async () => {
+      mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+      mockVault.getSecret.mockResolvedValue(apiKey);
+
+      const { ctx, request } = createHmacContext(apiKey, nodeId, '');
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      expect(request.nodeId).toBe(nodeId);
     });
   });
 });

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -7,9 +7,13 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createHash } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { PrismaService } from '../common/prisma.service';
 import { VaultService } from '../common/vault.service';
+import { safeCompare } from '../common/crypto.utils';
+
+/** Maximum allowed clock skew for HMAC timestamps (5 minutes). */
+const HMAC_TIMESTAMP_TOLERANCE_SECONDS = 300;
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate, OnModuleInit {
@@ -62,6 +66,16 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+
+    // HMAC path: check for HMAC signature headers first
+    const hmacSignature = request.headers['x-hmac-signature'] as
+      | string
+      | undefined;
+    if (hmacSignature) {
+      return this.validateHmac(request);
+    }
+
+    // Bearer path: existing token-based auth
     const authHeader: string | undefined = request.headers['authorization'];
 
     if (!authHeader?.startsWith('Bearer ')) {
@@ -98,5 +112,78 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
     }
 
     throw new UnauthorizedException('Invalid API key');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private async validateHmac(request: any): Promise<boolean> {
+    const signature = request.headers['x-hmac-signature'] as string;
+    const timestamp = request.headers['x-hmac-timestamp'] as string;
+    const keyId = request.headers['x-hmac-key-id'] as string;
+
+    if (!signature || !timestamp || !keyId) {
+      throw new UnauthorizedException('Missing HMAC headers');
+    }
+
+    // Validate timestamp (replay protection)
+    const requestTime = Number.parseInt(timestamp, 10);
+    if (Number.isNaN(requestTime)) {
+      throw new UnauthorizedException('Invalid HMAC timestamp');
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - requestTime) > HMAC_TIMESTAMP_TOLERANCE_SECONDS) {
+      throw new UnauthorizedException('HMAC timestamp expired');
+    }
+
+    // Look up the node
+    const node = await this.prisma.node.findUnique({ where: { id: keyId } });
+    if (!node) {
+      throw new UnauthorizedException('Unknown node');
+    }
+
+    if (
+      node.status !== 'certified' ||
+      !node.certificationExpiresAt ||
+      node.certificationExpiresAt <= new Date()
+    ) {
+      throw new UnauthorizedException('Node is not certified');
+    }
+
+    // Retrieve the API key from Vault
+    if (!node.apiKeySecretId) {
+      throw new UnauthorizedException('Node has no HMAC key configured');
+    }
+
+    let apiKey: string;
+    try {
+      const secret = await this.vault.getSecret(node.apiKeySecretId);
+      if (!secret) {
+        throw new Error('Secret not found');
+      }
+      apiKey = secret;
+    } catch {
+      throw new UnauthorizedException('Failed to retrieve node key');
+    }
+
+    // Compute expected signature
+    const rawBody = request.rawBody
+      ? Buffer.from(request.rawBody).toString('utf8')
+      : '';
+    const bodyHash = createHash('sha256').update(rawBody).digest('hex');
+    const method = request.method.toUpperCase();
+    const path = request.path || request.url;
+
+    const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+    const expectedSignature = createHmac('sha256', apiKey)
+      .update(signatureString)
+      .digest('base64');
+
+    if (!safeCompare(expectedSignature, signature)) {
+      throw new UnauthorizedException('Invalid HMAC signature');
+    }
+
+    request.region = node.region;
+    request.nodeId = node.id;
+    return true;
   }
 }

--- a/src/common/crypto.utils.spec.ts
+++ b/src/common/crypto.utils.spec.ts
@@ -1,0 +1,57 @@
+import { safeCompare, isNonEmptyString } from './crypto.utils';
+
+describe('crypto.utils', () => {
+  describe('safeCompare', () => {
+    it('should return true for identical strings', () => {
+      expect(safeCompare('hello', 'hello')).toBe(true);
+    });
+
+    it('should return false for different strings of same length', () => {
+      expect(safeCompare('hello', 'world')).toBe(false);
+    });
+
+    it('should return false for different lengths', () => {
+      expect(safeCompare('short', 'longer string')).toBe(false);
+    });
+
+    it('should return false for empty vs non-empty', () => {
+      expect(safeCompare('', 'hello')).toBe(false);
+    });
+
+    it('should return true for two empty strings', () => {
+      expect(safeCompare('', '')).toBe(true);
+    });
+
+    it('should return false for non-string inputs', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(safeCompare(null as any, 'hello')).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(safeCompare('hello', undefined as any)).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(safeCompare(123 as any, 456 as any)).toBe(false);
+    });
+
+    it('should handle base64 signature strings', () => {
+      const sig = 'dGVzdCBzaWduYXR1cmU=';
+      expect(safeCompare(sig, sig)).toBe(true);
+      expect(safeCompare(sig, 'ZGlmZmVyZW50IHNpZw==')).toBe(false);
+    });
+  });
+
+  describe('isNonEmptyString', () => {
+    it('should return true for non-empty strings', () => {
+      expect(isNonEmptyString('hello')).toBe(true);
+    });
+
+    it('should return false for empty strings', () => {
+      expect(isNonEmptyString('')).toBe(false);
+    });
+
+    it('should return false for non-string values', () => {
+      expect(isNonEmptyString(null)).toBe(false);
+      expect(isNonEmptyString(undefined)).toBe(false);
+      expect(isNonEmptyString(123)).toBe(false);
+      expect(isNonEmptyString({})).toBe(false);
+    });
+  });
+});

--- a/src/common/crypto.utils.ts
+++ b/src/common/crypto.utils.ts
@@ -1,0 +1,29 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ * Uses Node.js crypto.timingSafeEqual() which takes the same
+ * amount of time regardless of where strings differ.
+ *
+ * @see https://codahale.com/a-lesson-in-timing-attacks/
+ */
+export function safeCompare(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    return false;
+  }
+
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+
+  if (bufA.length !== bufB.length) {
+    // Compare bufA with itself to ensure constant time
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+
+  return timingSafeEqual(bufA, bufB);
+}
+
+export function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { rawBody: true });
 
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
 

--- a/test/integration/auth/auth.integration.spec.ts
+++ b/test/integration/auth/auth.integration.spec.ts
@@ -1,7 +1,13 @@
-import { post, apiPost, adminGet, get } from '../utils';
+import { createHash, createHmac } from 'node:crypto';
+import { post, apiPost, adminGet, adminPost, get, hmacPost } from '../utils';
+import { createTestNode, cleanupTestNodes } from '../utils/fixtures';
 import { INVALID_KEY, API_KEY } from '../utils/config';
 
 describe('Authentication (integration)', () => {
+  afterAll(async () => {
+    await cleanupTestNodes();
+  });
+
   describe('Node API key (prompt endpoints)', () => {
     it('should reject requests without auth', async () => {
       const res = await post('/prompts/rag', {
@@ -48,6 +54,102 @@ describe('Authentication (integration)', () => {
       const res = await adminGet('/admin/templates');
 
       expect(res.status).toBe(200);
+    });
+  });
+
+  describe('HMAC authentication', () => {
+    let nodeId: string;
+    let nodeApiKey: string;
+
+    beforeAll(async () => {
+      // Register and certify a node
+      const createRes = await createTestNode({
+        name: `integ-hmac-${Date.now()}`,
+        region: 'ca',
+      });
+      expect(createRes.status).toBe(201);
+      nodeId = createRes.body.id;
+      nodeApiKey = createRes.body.apiKey;
+
+      const certifyRes = await adminPost(`/admin/nodes/${nodeId}/certify`, {
+        body: { expiresInDays: 30 },
+      });
+      expect(certifyRes.status).toBe(201);
+    });
+
+    it('should authenticate with valid HMAC signature', async () => {
+      const body = { context: 'HMAC test context', query: 'HMAC test query' };
+      const res = await hmacPost('/prompts/rag', body, nodeApiKey, nodeId);
+
+      expect(res.status).toBe(201);
+      expect(res.body.promptText).toBeDefined();
+    });
+
+    it('should reject expired HMAC timestamp', async () => {
+      const body = { context: 'test', query: 'test' };
+      const bodyStr = JSON.stringify(body);
+      const expiredTimestamp = (Math.floor(Date.now() / 1000) - 600).toString();
+      const bodyHash = createHash('sha256').update(bodyStr).digest('hex');
+      const signatureString = `${expiredTimestamp}\nPOST\n/prompts/rag\n${bodyHash}`;
+      const signature = createHmac('sha256', nodeApiKey)
+        .update(signatureString)
+        .digest('base64');
+
+      const res = await post('/prompts/rag', {
+        body,
+        headers: {
+          'x-hmac-signature': signature,
+          'x-hmac-timestamp': expiredTimestamp,
+          'x-hmac-key-id': nodeId,
+        },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should reject tampered body', async () => {
+      // Sign with original body, send different body
+      const originalBody = { context: 'original', query: 'test' };
+      const tamperedBody = { context: 'tampered', query: 'test' };
+      const originalStr = JSON.stringify(originalBody);
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const bodyHash = createHash('sha256').update(originalStr).digest('hex');
+      const signatureString = `${timestamp}\nPOST\n/prompts/rag\n${bodyHash}`;
+      const signature = createHmac('sha256', nodeApiKey)
+        .update(signatureString)
+        .digest('base64');
+
+      const res = await post('/prompts/rag', {
+        body: tamperedBody,
+        headers: {
+          'x-hmac-signature': signature,
+          'x-hmac-timestamp': timestamp,
+          'x-hmac-key-id': nodeId,
+        },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should reject unknown node ID', async () => {
+      const body = { context: 'test', query: 'test' };
+      const res = await hmacPost(
+        '/prompts/rag',
+        body,
+        nodeApiKey,
+        '00000000-0000-0000-0000-000000000000',
+      );
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should still allow Bearer token auth (backward compat)', async () => {
+      const res = await post('/prompts/rag', {
+        body: { context: 'bearer test', query: 'bearer test' },
+        headers: { Authorization: `Bearer ${nodeApiKey}` },
+      });
+
+      expect(res.status).toBe(201);
     });
   });
 });

--- a/test/integration/utils/http-client.ts
+++ b/test/integration/utils/http-client.ts
@@ -1,3 +1,4 @@
+import { createHash, createHmac } from 'node:crypto';
 import { BASE_URL, API_KEY, ADMIN_API_KEY } from './config';
 
 interface RequestOptions {
@@ -70,3 +71,29 @@ export const adminPatch = (path: string, opts?: RequestOptions) =>
   patch(path, { ...opts, headers: withAuth(ADMIN_API_KEY, opts?.headers) });
 export const adminDelete = (path: string, opts?: RequestOptions) =>
   del(path, { ...opts, headers: withAuth(ADMIN_API_KEY, opts?.headers) });
+
+// HMAC-signed requests (node HMAC auth)
+export function hmacPost(
+  path: string,
+  body: unknown,
+  apiKey: string,
+  nodeId: string,
+): Promise<HttpResponse> {
+  const method = 'POST';
+  const bodyStr = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const bodyHash = createHash('sha256').update(bodyStr).digest('hex');
+  const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+  const signature = createHmac('sha256', apiKey)
+    .update(signatureString)
+    .digest('base64');
+
+  return request(method, path, {
+    body,
+    headers: {
+      'x-hmac-signature': signature,
+      'x-hmac-timestamp': timestamp,
+      'x-hmac-key-id': nodeId,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- Add HMAC-SHA256 request signing as an alternative to Bearer token auth for federated nodes
- The API key never leaves the node — each request is signed with a timestamp and body hash
- Provides replay protection (±5 min window), tamper detection, and key secrecy
- Bearer token auth remains fully supported for backward compatibility

## Changes

- **ApiKeyGuard**: HMAC validation path checks before Bearer token fallback
- **crypto.utils.ts**: Constant-time `safeCompare()` using `timingSafeEqual` (timing-attack safe)
- **main.ts**: Enable `rawBody: true` for body hash verification
- **Unit tests**: 13 HMAC test cases (valid sig, expired timestamp, tampered body, unknown node, etc.)
- **Integration tests**: 5 end-to-end HMAC auth tests
- **Postman**: HMAC Auth folder with pre-request signing scripts; Certify/Re-certify/Get/Rotate endpoints save `nodeApiKey` to environment
- **Docs**: HMAC protocol documented in API reference and README

## Test plan

- [x] All 172 unit tests pass (`pnpm test`)
- [x] Build and lint clean
- [x] Integration tests pass (HMAC + Bearer)
- [x] Postman HMAC flow tested end-to-end
- [x] Bearer token auth still works (backward compat)
- [x] Expired timestamp → 401
- [x] Tampered body → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)