### PR TITLE
feat: add scope field to structural analysis prompt (#558)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -58,14 +58,15 @@ Respond with ONLY valid JSON matching this exact structure (no markdown, no expl
   "fieldMappings": [
     {
       "fieldName": "the target field name",
-      "selector": "CSS selector relative to the item",
+      "selector": "CSS selector relative to the item (or container if scope is 'container')",
       "extractionMethod": "text|attribute|html|regex",
       "attribute": "only if extractionMethod is 'attribute'",
       "regexPattern": "only if extractionMethod is 'regex'",
       "regexGroup": 1,
       "transform": { "type": "transform_type", "params": {} },
       "required": true,
-      "defaultValue": "fallback if empty"
+      "defaultValue": "fallback if empty",
+      "scope": "item|container (default: item — use 'container' when the data is in a sibling/parent of items, not inside each item)"
     }
   ],
   "pagination": { "type": "none", "maxPages": 1 },
@@ -82,6 +83,7 @@ Respond with ONLY valid JSON matching this exact structure (no markdown, no expl
 6. If the page has multiple formats (e.g., table AND heading-based), choose the PRIMARY format
 7. The containerSelector should match exactly ONE element
 8. The itemSelector should match MULTIPLE elements within the container
+9. Use "scope": "container" when a field's data lives OUTSIDE the item elements (e.g., a heading above the items that applies to all of them). The selector is then relative to the container, not the item.
 
 ## HTML to Analyze
 \`\`\`html


### PR DESCRIPTION
## Summary
- Add `scope` field to the `fieldMappings` JSON structure in the structural analysis prompt template
- Add Rule 9: use `"scope": "container"` when field data lives outside item elements (e.g., headings above items)

## Why
Companion change to OpusPopuli/opuspopuli#583. The AI needs to know about the `scope` option so it can generate manifests with `scope: "container"` for fields like `electionDate` that live in sibling headings.

## Test plan
- [x] Verified prompt service starts and seeds updated template
- [x] Verified AI generates manifest with `"scope": "container"` on `electionDate` in UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)