### PR TITLE
feat: structured array extraction support in prompt template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,13 @@ services:
     image: opuspopuli-prompts
     container_name: opuspopuli-prompts
     ports:
-      - '3200:3200'
+      - '3210:3210'
     environment:
       DATABASE_URL: postgresql://postgres:postgres@opuspopuli-prompts-db:5432/prompt_service?schema=public
       API_KEYS: dev-key-1,dev-key-2
       ADMIN_API_KEYS: admin-dev-key-1
       PROMPT_TTL_SECONDS: 3600
-      PORT: 3200
+      PORT: 3210
     depends_on:
       opuspopuli-prompts-db:
         condition: service_healthy

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -57,16 +57,17 @@ Respond with ONLY valid JSON matching this exact structure (no markdown, no expl
   "itemSelector": "CSS selector for each individual item (relative to container)",
   "fieldMappings": [
     {
-      "fieldName": "the target field name",
+      "fieldName": "the target field name (use dot notation for nested: 'contactInfo.email')",
       "selector": "CSS selector relative to the item (or container if scope is 'container')",
-      "extractionMethod": "text|attribute|html|regex",
+      "extractionMethod": "text|attribute|html|regex|structured",
       "attribute": "only if extractionMethod is 'attribute'",
       "regexPattern": "only if extractionMethod is 'regex'",
       "regexGroup": 1,
       "transform": { "type": "transform_type", "params": {} },
       "required": true,
       "defaultValue": "fallback if empty",
-      "scope": "item|container (default: item — use 'container' when the data is in a sibling/parent of items, not inside each item)"
+      "scope": "item|container (default: item — use 'container' when the data is in a sibling/parent of items, not inside each item)",
+      "children": { "childField": "CSS selector for child" }
     }
   ],
   "pagination": { "type": "none", "maxPages": 1 },
@@ -84,6 +85,23 @@ Respond with ONLY valid JSON matching this exact structure (no markdown, no expl
 7. The containerSelector should match exactly ONE element
 8. The itemSelector should match MULTIPLE elements within the container
 9. Use "scope": "container" when a field's data lives OUTSIDE the item elements (e.g., a heading above the items that applies to all of them). The selector is then relative to the container, not the item.
+10. Use "extractionMethod": "structured" with a "children" object when a field is an ARRAY of nested objects (e.g., multiple offices per representative, multiple committees per member). The "selector" matches each repeating child element inside the item, and "children" maps each sub-field name to its CSS selector relative to the repeating element. Example:
+    {
+      "fieldName": "contactInfo.offices",
+      "selector": ".member__office",
+      "extractionMethod": "structured",
+      "children": {
+        "name": ".office-title",
+        "address": ".address",
+        "phone": ".phone"
+      },
+      "required": false
+    }
+    Child selectors support:
+    - Standard CSS selectors (e.g., "h3", ".class")
+    - "|attr:attrName" suffix to extract an attribute (e.g., "a|attr:href")
+    - "_text" special value: grabs the full text content of the repeating element
+    - "_regex:PATTERN" special value: extracts via regex from element text (e.g., "_regex:Phone:\\s*([\\d()\\s-]+)")
 
 ## HTML to Analyze
 \`\`\`html


### PR DESCRIPTION
## Summary
Extend the structural-analysis prompt to teach the AI about the new \`extractionMethod: \"structured\"\` with a \`children\` config. This enables extracting arrays of nested objects directly from listing pages (e.g., multiple offices per senator, multiple committees per member).

Also fixes the container port from 3200 to 3210 to avoid conflict with Grafana Tempo.

## Changes
- **\`prisma/seed.ts\`** — Added \`children\` field to fieldMappings schema; added Rule 10 with example + documentation of child selectors (\`_text\`, \`_regex:PATTERN\`, \`|attr:name\`)
- **\`docker-compose.yml\`** — Changed port 3200 → 3210 (Tempo uses 3200)

## Companion
Companion to the opuspopuli repo changes that add \`structured\` extractionMethod support to \`ManifestExtractorService\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)