### PR TITLE
Merge develop to main: bio prompt template + hash endpoint

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -214,6 +214,154 @@ Respond with JSON:
   },
 
   {
+    name: 'document-analysis-representative-bio',
+    category: 'document_analysis',
+    description:
+      'Generate a claim-tagged biography for a legislator, drawing on authoritative source data plus high-confidence training knowledge',
+    variables: ['TEXT'],
+    templateText: `You are a civic data writer for Opus Populi. You generate biographies of
+elected representatives using authoritative source data supplemented by
+your general knowledge. Your output must be verifiable and neutral, with
+every claim explicitly tagged by its origin.
+
+<source_data>
+{{TEXT}}
+</source_data>
+
+═══════════════════════════════════════════════════════════════
+KNOWLEDGE TIERS
+═══════════════════════════════════════════════════════════════
+
+You may draw on two knowledge sources, in strict priority order:
+
+TIER 1 — SOURCE DATA (authoritative)
+The structured data provided in <source_data>. This is ground truth. If
+source data contradicts your training knowledge, source data wins. Always.
+
+TIER 2 — TRAINING KNOWLEDGE (supplementary)
+Facts you know from training that are not in the source data. Use only
+when:
+  (a) the fact adds material civic value (office held, legislation, public
+      record of activity, professional background),
+  (b) you have high confidence the fact is accurate, and
+  (c) the fact does not conflict with source data.
+
+Do not use training knowledge for:
+  - Current committee assignments, chairmanships, or leadership positions
+    (these change each session and your training data is stale)
+  - Specific bill numbers or bill status
+  - Current term dates or election results after your training cutoff
+  - Dollar figures for budgets overseen
+  - Personal details (family, residence, pets) not in source data
+  - Any fact about a representative you do not clearly recognize
+
+If you do not clearly recognize the representative, use only source data.
+Uncertainty is not a reason to guess; it is a reason to omit.
+
+═══════════════════════════════════════════════════════════════
+FACTUALITY RULES — NON-NEGOTIABLE
+═══════════════════════════════════════════════════════════════
+
+RULE 1: NO INFERENCE OR CHARACTERIZATION
+Restate facts. Do not characterize, summarize, or interpret them.
+  - "teacher for 20 years" → do not write "veteran educator"
+  - "chairs Health Subcommittee" → do not write "healthcare expert"
+  - three environmental bills listed → do not write "environmental leader"
+  - "Democrat" → do not write "progressive" or "moderate"
+  - "first Democrat since 1947" → do not write "historic victory"
+
+RULE 2: NO EVALUATIVE LANGUAGE
+Forbidden regardless of context:
+  - Achievement: tireless, dedicated, devoted, passionate, committed,
+    fierce, strong, effective, accomplished, distinguished, respected, proven
+  - Advocacy: champion, fighter, advocate, defender, warrior, voice, ally
+  - Direction: progressive, conservative, moderate, liberal, right-wing,
+    left-wing, radical, mainstream (exception: official caucus/party names)
+  - Quality: notable, significant, important, key, leading, prominent,
+    renowned, acclaimed, celebrated
+  - Emotional: proud, honored, humbled
+  - Editorial transitions: notably, importantly, of note, it is worth noting,
+    it should be mentioned, remarkably
+
+Use neutral verbs: represents, chairs, serves, introduced, voted, graduated,
+worked, holds, was elected, was appointed, co-founded.
+
+RULE 3: NO MOTIVATION ATTRIBUTION
+Report actions, not reasons.
+  - Forbidden: "Motivated by her teaching background, she..."
+  - Allowed: "After teaching for 20 years, she was elected..."
+
+RULE 4: MISSING DATA
+If neither source data nor reliable training knowledge supports a claim,
+omit the corresponding sentence. Do not guess. Do not pad.
+
+RULE 5: CONFLICTS
+Source data always wins over training knowledge. If your training data says
+something different than source data, use source data and discard the
+training fact silently.
+
+RULE 6: NO QUOTATION
+Do not quote source material. Proper nouns, official titles, bill numbers,
+and organization names are used directly and are not quotations.
+
+═══════════════════════════════════════════════════════════════
+STRUCTURE — FIVE PARAGRAPHS IN ORDER
+═══════════════════════════════════════════════════════════════
+
+Omit any paragraph for which information is insufficient.
+
+1. IDENTITY & MANDATE — name, party-city, chamber, district, geography,
+   election history, term end.
+2. POWER & RESPONSIBILITIES — chairmanships, memberships, external
+   appointments, caucus leadership. [SOURCE DATA ONLY — do not supplement
+   from training knowledge; committee rosters change each session.]
+3. PRIORITIES & RECORD — focus areas, bills by number and short title,
+   caucus memberships, policy-related recognitions.
+4. BACKGROUND & QUALIFICATIONS — prior profession, tenure, degrees,
+   institutions, credentials, languages.
+5. CIVIC & COMMUNITY ROOTS — prior offices with dates, community roles,
+   founding roles. Closing sentence of residence/family context only if in
+   source data.
+
+Target 250-400 words. No paragraph over 100 words. Use surname after first
+full-name introduction. Present tense for current roles, past tense for
+prior roles.
+
+═══════════════════════════════════════════════════════════════
+SELF-CHECK BEFORE OUTPUT
+═══════════════════════════════════════════════════════════════
+
+  □ Every sentence is either from source data or from high-confidence
+    training knowledge.
+  □ No current committee/bill facts are drawn from training knowledge.
+  □ No forbidden words appear.
+  □ No causal or motivational language.
+  □ No characterizations of the person.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT
+═══════════════════════════════════════════════════════════════
+
+Return a single JSON object, and nothing else:
+
+{
+  "bio": "Five paragraphs separated by \\n\\n",
+  "wordCount": <integer>,
+  "claims": [
+    {
+      "sentence": "Verbatim sentence from the bio.",
+      "origin": "source" | "training",
+      "sourceField": "dot.path.in.source_data or null",
+      "confidence": "high" | "medium"
+    }
+  ]
+}
+
+Every sentence in the bio must appear as one entry in claims. No markdown
+fences. No commentary outside the JSON.`,
+  },
+
+  {
     name: 'document-analysis-proposition',
     category: 'document_analysis',
     description: 'Ballot proposition analysis prompt',

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -20,6 +20,7 @@ describe('PromptsController', () => {
             getDocumentAnalysisPrompt: jest.fn(),
             getRagPrompt: jest.fn(),
             verifyPrompt: jest.fn(),
+            getPromptHash: jest.fn(),
           },
         },
         {
@@ -126,6 +127,21 @@ describe('PromptsController', () => {
     const result = await controller.verify(dto);
 
     expect(service.verifyPrompt).toHaveBeenCalledWith('hash123', 'v1');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getPromptHash with the name param', async () => {
+    const expected = {
+      name: 'structural-analysis',
+      promptHash: 'abc',
+      promptVersion: 'v1',
+    };
+
+    jest.spyOn(service, 'getPromptHash').mockResolvedValue(expected);
+
+    const result = await controller.hash('structural-analysis');
+
+    expect(service.getPromptHash).toHaveBeenCalledWith('structural-analysis');
     expect(result).toEqual(expected);
   });
 });

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -91,5 +99,26 @@ export class PromptsController {
   @ApiResponse({ status: 401, description: 'Invalid API key' })
   async verify(@Body() dto: VerifyPromptDto) {
     return this.promptsService.verifyPrompt(dto.promptHash, dto.promptVersion);
+  }
+
+  /**
+   * Return the current hash + version of a named template, with no
+   * interpolation. Used by clients to cheaply check whether a cached prompt
+   * is stale (SHA-256 of the bare template text). Authoritative source of
+   * truth for manifest cache invalidation.
+   */
+  @Get(':name/hash')
+  @UseGuards(ApiKeyGuard)
+  @ApiBearerAuth()
+  @Throttle({ default: { ttl: 60_000, limit: 120 } })
+  @ApiOperation({ summary: 'Get the hash of a named prompt template' })
+  @ApiResponse({
+    status: 200,
+    description: 'Current hash + version of the template',
+  })
+  @ApiResponse({ status: 401, description: 'Invalid API key' })
+  @ApiResponse({ status: 404, description: 'Template not found' })
+  async hash(@Param('name') name: string) {
+    return this.promptsService.getPromptHash(name);
   }
 }

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -269,6 +269,50 @@ describe('PromptsService', () => {
     });
   });
 
+  describe('getPromptHash', () => {
+    it('returns SHA-256 hash + version of the active template', async () => {
+      const templateText = 'bare template text';
+      const expectedHash = createHash('sha256')
+        .update(templateText)
+        .digest('hex');
+
+      prisma.promptTemplate.findFirst.mockResolvedValue({
+        id: '1',
+        name: 'structural-analysis',
+        templateText,
+        version: 3,
+        isActive: true,
+      });
+
+      const result = await service.getPromptHash('structural-analysis');
+
+      expect(result).toEqual({
+        name: 'structural-analysis',
+        promptHash: expectedHash,
+        promptVersion: 'v3',
+      });
+    });
+
+    it('throws NotFoundException when template is missing', async () => {
+      prisma.promptTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(service.getPromptHash('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('ignores inactive templates', async () => {
+      prisma.promptTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(service.getPromptHash('inactive')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.promptTemplate.findFirst).toHaveBeenCalledWith({
+        where: { name: 'inactive', isActive: true },
+      });
+    });
+  });
+
   describe('verifyPrompt', () => {
     it('should return valid for matching hash', async () => {
       const templateText = 'test template';

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -19,6 +19,12 @@ export interface VerifyResult {
   templateName?: string;
 }
 
+export interface PromptHashResult {
+  name: string;
+  promptHash: string;
+  promptVersion: string;
+}
+
 interface ResolvedTemplate {
   templateText: string;
   version: number;
@@ -141,6 +147,27 @@ export class PromptsService {
     );
 
     return response;
+  }
+
+  /**
+   * Return the current hash + version of a named template, no interpolation.
+   * Used by clients to check whether their cached prompt is stale without
+   * paying the cost of fetching the full rendered prompt.
+   */
+  async getPromptHash(name: string): Promise<PromptHashResult> {
+    const template = await this.prisma.promptTemplate.findFirst({
+      where: { name, isActive: true },
+    });
+
+    if (!template) {
+      throw new NotFoundException(`Prompt template "${name}" not found`);
+    }
+
+    return {
+      name: template.name,
+      promptHash: this.hash(template.templateText),
+      promptVersion: `v${template.version}`,
+    };
   }
 
   async verifyPrompt(


### PR DESCRIPTION
## Summary

Promotes the changes from develop to main. Includes one merged feature PR:

### [#22](https://github.com/OpusPopuli/prompt-service/pull/22) — Add bio prompt template and hash endpoint

- **New template**: \`document-analysis-representative-bio\` — claim-tagged 5-paragraph biography with knowledge tiers, forbidden-word list, and self-check. Consumed by the new \`BioGeneratorService\` in opuspopuli ([#596](https://github.com/OpusPopuli/opuspopuli/issues/596)).
- **New endpoint**: \`GET /prompts/:name/hash\` — cheap hash-only lookup (SHA-256 of bare template text + version). ApiKey-guarded, rate-limited to 120/min. Authoritative source for manifest cache invalidation on client side. Resolves [opuspopuli#605](https://github.com/OpusPopuli/opuspopuli/issues/605) — the prompt-hash asymmetry that was causing permanent cache misses.

## Post-merge

- Production prompt-service needs a reseed to pick up the new bio template. (Template is upserted on app startup via \`node dist/seed/seed.js\` in the Docker CMD — a rolling restart of the prompt-service container handles this.)

## Test plan

- [x] All unit tests pass (23/23 across prompts controller + service)
- [x] Hash endpoint verified end-to-end against opuspopuli region container (manifest cache now hits reliably)
- [x] Bio prompt template validated via live AI bio generation tonight in UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)