### PR TITLE
Release: production launch-blockers (#24, #25, #26)

### DIFF
--- a/postman/prompt-service.postman_collection.json
+++ b/postman/prompt-service.postman_collection.json
@@ -171,6 +171,37 @@
             },
             "url": { "raw": "{{baseUrl}}/prompts/verify", "host": ["{{baseUrl}}"], "path": ["prompts", "verify"] }
           }
+        },
+        {
+          "name": "Get Prompt Hash",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has name, promptHash, promptVersion', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('name');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "  pm.expect(body).to.have.property('promptVersion');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{apiKey}}" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/prompts/structural-analysis/hash",
+              "host": ["{{baseUrl}}"],
+              "path": ["prompts", "structural-analysis", "hash"]
+            },
+            "description": "Returns the current SHA-256 hash and version of a named template with no interpolation. Used by clients to cheaply check whether a cached prompt is stale without fetching the full rendered prompt. Authoritative source of truth for manifest cache invalidation."
+          }
         }
       ]
     },

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -324,6 +324,10 @@ describe('ApiKeyGuard', () => {
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(request.region).toBe('ca');
       expect(request.nodeId).toBe(nodeId);
+      // Downstream audit logging expects req.apiKey to be populated in
+      // both auth paths — without this, apiKey.slice(...) throws on the
+      // HMAC path and surfaces as a 500.
+      expect(request.apiKey).toBe(apiKey);
     });
 
     it('should reject expired timestamp (past)', async () => {

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -182,6 +182,11 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
       throw new UnauthorizedException('Invalid HMAC signature');
     }
 
+    // Propagate the authenticated secret so downstream audit logging
+    // (apiKeyPrefix) can record which key served the request, matching
+    // the Bearer path's behavior. Without this, audit-log writes throw
+    // on `undefined.slice` for HMAC-signed requests.
+    request.apiKey = apiKey;
     request.region = node.region;
     request.nodeId = node.id;
     return true;

--- a/src/common/vault.service.spec.ts
+++ b/src/common/vault.service.spec.ts
@@ -100,6 +100,47 @@ describe('VaultService', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('should escape SQL LIKE wildcards in the prefix', async () => {
+      prisma.$queryRaw.mockResolvedValue([]);
+
+      await service.getSecretsByPrefix('weird_%_\\prefix');
+
+      // The template-tag values array is passed as the second arg to the
+      // tagged template function; we assert the pattern value, not the SQL.
+      const call = prisma.$queryRaw.mock.calls[0];
+      const values = call.slice(1);
+      expect(values).toContain('weird\\_\\%\\_\\\\prefix%');
+    });
+  });
+
+  describe('onApplicationBootstrap', () => {
+    const originalEnv = process.env.NODE_ENV;
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('should resolve silently when Vault is reachable', async () => {
+      prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+    });
+
+    it('should throw in production when Vault is unreachable', async () => {
+      process.env.NODE_ENV = 'production';
+      prisma.$queryRaw.mockRejectedValue(new Error('vault offline'));
+
+      await expect(service.onApplicationBootstrap()).rejects.toThrow(
+        'vault offline',
+      );
+    });
+
+    it('should warn but continue in dev when Vault is unreachable', async () => {
+      process.env.NODE_ENV = 'development';
+      prisma.$queryRaw.mockRejectedValue(new Error('vault offline'));
+
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+    });
   });
 
   describe('updateSecret', () => {

--- a/src/common/vault.service.ts
+++ b/src/common/vault.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 
 interface VaultSecret {
@@ -8,10 +8,40 @@ interface VaultSecret {
 }
 
 @Injectable()
-export class VaultService {
+export class VaultService implements OnApplicationBootstrap {
   private readonly logger = new Logger(VaultService.name);
 
   constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Verify Vault connectivity at startup. In production, failure aborts
+   * the app boot — the orchestrator will restart/alert. In dev, we log
+   * a warning and continue so local development doesn't require a
+   * fully-configured Supabase Vault.
+   *
+   * This prevents silently falling back to env-var keys when Vault is
+   * unreachable, which would bypass the key-rotation mechanism. See #24.
+   */
+  async onApplicationBootstrap(): Promise<void> {
+    try {
+      // Lightweight probe: SELECT a known vault schema object. If Vault
+      // is unreachable, Prisma raises before returning any rows.
+      await this.prisma
+        .$queryRaw`SELECT 1 FROM vault.decrypted_secrets LIMIT 1`;
+      this.logger.log('Vault connectivity verified');
+    } catch (error) {
+      const message = `Vault is not reachable at startup: ${(error as Error).message}`;
+      if (process.env.NODE_ENV === 'production') {
+        this.logger.error(
+          `${message}. Aborting boot — refusing to run with stale env-var-fallback keys in production.`,
+        );
+        throw error;
+      }
+      this.logger.warn(
+        `${message}. Continuing in ${process.env.NODE_ENV ?? 'dev'} mode with env-var fallback; would ABORT in production.`,
+      );
+    }
+  }
 
   async createSecret(
     value: string,
@@ -43,14 +73,30 @@ export class VaultService {
     return result[0]?.secret ?? null;
   }
 
+  /**
+   * Escape SQL LIKE wildcards in user-controlled input so the caller's
+   * prefix is treated literally. Without this, a prefix containing `%`
+   * or `_` would silently broaden the match — an enumeration vector if
+   * the prefix ever comes from outside the trusted code path.
+   *
+   * Pairs with the `ESCAPE '\\'` clause in the query below.
+   * See issue #24.
+   */
+  private escapeLikePattern(input: string): string {
+    return input
+      .replace(/\\/g, '\\\\')
+      .replace(/%/g, '\\%')
+      .replace(/_/g, '\\_');
+  }
+
   async getSecretsByPrefix(
     prefix: string,
   ): Promise<{ name: string; secret: string }[]> {
-    const pattern = `${prefix}%`;
+    const pattern = `${this.escapeLikePattern(prefix)}%`;
     const result = await this.prisma.$queryRaw<VaultSecret[]>`
       SELECT id::text, name, decrypted_secret AS secret
       FROM vault.decrypted_secrets
-      WHERE name LIKE ${pattern}
+      WHERE name LIKE ${pattern} ESCAPE '\'
     `;
     return result.map((r) => ({ name: r.name, secret: r.secret }));
   }

--- a/src/common/vault.service.ts
+++ b/src/common/vault.service.ts
@@ -84,9 +84,9 @@ export class VaultService implements OnApplicationBootstrap {
    */
   private escapeLikePattern(input: string): string {
     return input
-      .replace(/\\/g, '\\\\')
-      .replace(/%/g, '\\%')
-      .replace(/_/g, '\\_');
+      .replaceAll('\\', String.raw`\\`)
+      .replaceAll('%', String.raw`\%`)
+      .replaceAll('_', String.raw`\_`);
   }
 
   async getSecretsByPrefix(

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,36 +1,70 @@
+import { HttpStatus } from '@nestjs/common';
+import type { Response } from 'express';
 import { HealthController } from './health.controller';
 
 describe('HealthController', () => {
   let controller: HealthController;
   let prisma: { $queryRaw: jest.Mock; promptTemplate: { count: jest.Mock } };
+  let prompts: { getAuditLogFailureCount: jest.Mock };
+  let res: { status: jest.Mock };
 
   beforeEach(() => {
     prisma = {
       $queryRaw: jest.fn(),
       promptTemplate: { count: jest.fn() },
     };
-    controller = new HealthController(prisma as never);
+    prompts = { getAuditLogFailureCount: jest.fn().mockReturnValue(0) };
+    res = { status: jest.fn() };
+    controller = new HealthController(prisma as never, prompts as never);
   });
 
   it('should return ok when database is connected', async () => {
     prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
     prisma.promptTemplate.count.mockResolvedValue(13);
 
-    const result = await controller.check();
+    const result = await controller.check(res as unknown as Response);
 
     expect(result.status).toBe('ok');
     expect(result.database).toBe('connected');
     expect(result.activeTemplates).toBe(13);
+    expect(result.auditLogFailures).toBe(0);
     expect(result.timestamp).toBeDefined();
+    expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('should return degraded when database is down', async () => {
+  it('should return 503 with error status when database is down', async () => {
     prisma.$queryRaw.mockRejectedValue(new Error('connection refused'));
+    prompts.getAuditLogFailureCount.mockReturnValue(2);
 
-    const result = await controller.check();
+    const result = await controller.check(res as unknown as Response);
 
-    expect(result.status).toBe('degraded');
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.SERVICE_UNAVAILABLE);
+    expect(result.status).toBe('error');
     expect(result.database).toBe('disconnected');
-    expect(result.activeTemplates).toBe(0);
+    expect(result.auditLogFailures).toBe(2);
+    expect(result.detail).toContain('connection refused');
+    expect(prisma.promptTemplate.count).not.toHaveBeenCalled();
+  });
+
+  it('should expose audit log failure count on healthy response', async () => {
+    prisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+    prisma.promptTemplate.count.mockResolvedValue(5);
+    prompts.getAuditLogFailureCount.mockReturnValue(7);
+
+    const result = await controller.check(res as unknown as Response);
+
+    expect(result.status).toBe('ok');
+    expect(result.auditLogFailures).toBe(7);
+  });
+
+  it('should redact multi-line db error detail and cap at 120 chars', async () => {
+    const huge = 'line1: ' + 'X'.repeat(200) + '\nline2: secret-conn-string';
+    prisma.$queryRaw.mockRejectedValue(new Error(huge));
+
+    const result = await controller.check(res as unknown as Response);
+
+    expect(result.detail).toBeDefined();
+    expect(result.detail!.length).toBeLessThanOrEqual(120);
+    expect(result.detail).not.toContain('secret-conn-string');
   });
 });

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,32 +1,71 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, HttpStatus, Logger, Res } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Response } from 'express';
 import { PrismaService } from '../common/prisma.service';
+import { PromptsService } from '../prompts/prompts.service';
 
+/**
+ * Health check for container orchestrators + monitoring.
+ *
+ * Returns 200 with status=ok when the database is reachable and the
+ * template store is queryable. Returns 503 with status=error when the
+ * database is unreachable so orchestrators can pull unhealthy instances
+ * out of rotation and alerting surfaces the outage. See issue #25.
+ */
 @ApiTags('health')
 @Controller('health')
 export class HealthController {
-  constructor(private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(HealthController.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly prompts: PromptsService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'Health check' })
-  async check() {
+  @ApiResponse({ status: 200, description: 'Healthy' })
+  @ApiResponse({ status: 503, description: 'Unhealthy — database unreachable' })
+  async check(@Res({ passthrough: true }) res: Response) {
     let dbHealthy = false;
+    let dbErrorDetail: string | undefined;
     try {
       await this.prisma.$queryRaw`SELECT 1`;
       dbHealthy = true;
-    } catch {
-      // DB is down
+    } catch (error) {
+      // Capture the error class/short message but NOT the full stack or
+      // any connection string that Prisma might include in the detail.
+      const raw = (error as Error).message ?? 'unknown database error';
+      dbErrorDetail = raw.split('\n')[0].slice(0, 120);
+      this.logger.error(`Health probe failed: database unreachable`);
     }
 
     const templateCount = dbHealthy
       ? await this.prisma.promptTemplate.count({ where: { isActive: true } })
       : 0;
 
+    // Exposed for ops visibility into dropped audit logs (see #25).
+    // Doesn't affect the health status itself — audit failures are
+    // non-fatal — but ops can alert on trend.
+    const auditLogFailures = this.prompts.getAuditLogFailureCount();
+
+    if (!dbHealthy) {
+      res.status(HttpStatus.SERVICE_UNAVAILABLE);
+      return {
+        status: 'error',
+        timestamp: new Date().toISOString(),
+        database: 'disconnected',
+        detail: dbErrorDetail,
+        auditLogFailures,
+      };
+    }
+
     return {
-      status: dbHealthy ? 'ok' : 'degraded',
+      status: 'ok',
       timestamp: new Date().toISOString(),
-      database: dbHealthy ? 'connected' : 'disconnected',
+      database: 'connected',
       activeTemplates: templateCount,
+      auditLogFailures,
     };
   }
 }

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { PromptsModule } from '../prompts/prompts.module';
 import { HealthController } from './health.controller';
 
 @Module({
+  imports: [PromptsModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/src/prompts/prompts.module.ts
+++ b/src/prompts/prompts.module.ts
@@ -5,5 +5,6 @@ import { PromptsService } from './prompts.service';
 @Module({
   controllers: [PromptsController],
   providers: [PromptsService],
+  exports: [PromptsService],
 })
 export class PromptsModule {}

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -37,6 +37,19 @@ interface ResolvedTemplate {
 export class PromptsService {
   private readonly logger = new Logger(PromptsService.name);
 
+  /**
+   * Running count of audit-log write failures. Exposed to let ops
+   * dashboards (and `/health`) notice when the audit trail is dropping
+   * without needing a full Prometheus integration — that's tracked in
+   * #27 as a separate follow-up. See #25.
+   */
+  private auditLogFailureCount = 0;
+
+  /** Total audit-log write failures since process start. */
+  getAuditLogFailureCount(): number {
+    return this.auditLogFailureCount;
+  }
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly config: ConfigService,
@@ -284,7 +297,23 @@ export class PromptsService {
         },
       });
     } catch (err) {
-      this.logger.warn(`Failed to log prompt request: ${err}`);
+      // Upgrade from warn → error so log-based alerting catches this.
+      // Audit logs are compliance-critical for a nonpartisan civic
+      // platform; silently losing them is NOT acceptable. We don't
+      // block the prompt response (audit is downstream of serving),
+      // but we surface the failure loudly. See #25.
+      this.auditLogFailureCount += 1;
+      this.logger.error(
+        {
+          event: 'audit_log_write_failure',
+          endpoint,
+          region,
+          apiKeyPrefix: apiKey.slice(0, 8) + '...',
+          cumulativeFailures: this.auditLogFailureCount,
+          error: (err as Error).message,
+        },
+        `Failed to write prompt request audit log (failures so far: ${this.auditLogFailureCount})`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary
Promotes the launch-blocker fixes from `develop` to `main` (closes #24, #25, #26).

- **#24 Vault hardening** — SQL LIKE wildcard escape in `getSecretsByPrefix` + `onApplicationBootstrap` probe that fails startup in production when Vault is unreachable (prevents silent env-var key fallback).
- **#25 Health + audit observability** — `/health` returns 503 with a redacted single-line error detail when the DB is unreachable; cumulative `auditLogFailures` counter surfaced on /health; audit-log write failures upgraded to `logger.error` with structured context.
- **#26 Postman** — `GET /prompts/:name/hash` request added to the Prompts folder.
- **Bonus** — HMAC guard now propagates `req.apiKey` so audit logging works for HMAC-signed requests (regression surfaced by the stricter error handler above).

## Test plan
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 182/182 pass
- [x] `pnpm test:integration:docker` — 79/79 pass
- [x] Local Docker deploy: healthy probe, new hash endpoint returns 200, /health returns 503 when DB stopped and recovers to 200 on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)