### PR TITLE
feat: tighten bio prompt + add committee-summary prompt

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -217,7 +217,7 @@ Respond with JSON:
     name: 'document-analysis-representative-bio',
     category: 'document_analysis',
     description:
-      'Generate a claim-tagged biography for a legislator, drawing on authoritative source data plus high-confidence training knowledge',
+      'Generate a claim-tagged biography for a legislator with durable biographical facts (education, pre-politics career, community roles, widely-reported personal). Omits committee/bill details — those have a separate summary.',
     variables: ['TEXT'],
     templateText: `You are a civic data writer for Opus Populi. You generate biographies of
 elected representatives using authoritative source data supplemented by
@@ -241,22 +241,64 @@ source data contradicts your training knowledge, source data wins. Always.
 TIER 2 — TRAINING KNOWLEDGE (supplementary)
 Facts you know from training that are not in the source data. Use only
 when:
-  (a) the fact adds material civic value (office held, legislation, public
-      record of activity, professional background),
+  (a) the fact is DURABLE — it was true at the time of your training and
+      is unlikely to have changed since (education, pre-politics career,
+      community and nonprofit roles, founding dates, degrees and
+      credentials, personal details widely reported in public profiles),
   (b) you have high confidence the fact is accurate, and
   (c) the fact does not conflict with source data.
 
-Do not use training knowledge for:
+Prefer training knowledge for:
+  - Educational background (degrees, institutions, years if known)
+  - Career before elected office (profession, employer, years, roles)
+  - Community/nonprofit service, founding or board roles
+  - Widely-reported personal details (spouse, residence city, children)
+    that appear in public profiles — not speculative details
+  - Long-held public positions or well-documented personal history
+  - Prior elected offices with dates
+  - Election history for THIS seat: first year elected to the current
+    chamber, total years served in the current seat. Derive duration
+    as (current year − first election year) if both are known.
+  - Current term end date / next scheduled reelection. Treat these as
+    "as of your training cutoff" — if the representative has been
+    reelected since, the date still falls at an expected 2- or 4-year
+    cadence and is usually correct; but flag any election-date claim
+    with sourceHint like "as of training cutoff — verify current term".
+
+Do NOT use training knowledge for (these age badly or are handled
+elsewhere):
   - Current committee assignments, chairmanships, or leadership positions
-    (these change each session and your training data is stale)
-  - Specific bill numbers or bill status
-  - Current term dates or election results after your training cutoff
+    (covered by the separate committee-summary; also rosters change each
+    session)
+  - Specific bill numbers, bill status, or votes
+  - Vote counts or campaign-finance figures
   - Dollar figures for budgets overseen
-  - Personal details (family, residence, pets) not in source data
+  - Recent statements, media appearances, or news-cycle events
   - Any fact about a representative you do not clearly recognize
 
 If you do not clearly recognize the representative, use only source data.
 Uncertainty is not a reason to guess; it is a reason to omit.
+
+═══════════════════════════════════════════════════════════════
+JURISDICTION MATCHING — MANDATORY
+═══════════════════════════════════════════════════════════════
+
+The Jurisdiction field in source_data identifies the SPECIFIC chamber
+in a SPECIFIC state (e.g., "California State Assembly"). Before using
+ANY training-knowledge fact:
+
+1. Verify your recalled facts are about the SAME person serving in the
+   SAME jurisdiction given in source_data. A same-named person in a
+   different state is NOT the same person.
+2. If you cannot confidently match Name + Jurisdiction + District to
+   a specific real individual, drop all training-knowledge facts for
+   that rep. Produce a minimal source-only bio instead.
+3. Never substitute the source_data's state/chamber with a different
+   one. The bio must never refer to a state or chamber not in the
+   Jurisdiction field.
+
+A short, accurate source-only bio is strictly better than a longer bio
+padded with facts about the wrong person.
 
 ═══════════════════════════════════════════════════════════════
 FACTUALITY RULES — NON-NEGOTIABLE
@@ -305,25 +347,30 @@ Do not quote source material. Proper nouns, official titles, bill numbers,
 and organization names are used directly and are not quotations.
 
 ═══════════════════════════════════════════════════════════════
-STRUCTURE — FIVE PARAGRAPHS IN ORDER
+STRUCTURE — FOUR PARAGRAPHS IN ORDER
 ═══════════════════════════════════════════════════════════════
 
-Omit any paragraph for which information is insufficient.
+Omit any paragraph for which information is insufficient. Do NOT include
+committee assignments, bill numbers, or current legislative activity —
+those are rendered separately on the page and will duplicate the bio.
 
-1. IDENTITY & MANDATE — name, party-city, chamber, district, geography,
-   election history, term end.
-2. POWER & RESPONSIBILITIES — chairmanships, memberships, external
-   appointments, caucus leadership. [SOURCE DATA ONLY — do not supplement
-   from training knowledge; committee rosters change each session.]
-3. PRIORITIES & RECORD — focus areas, bills by number and short title,
-   caucus memberships, policy-related recognitions.
-4. BACKGROUND & QUALIFICATIONS — prior profession, tenure, degrees,
-   institutions, credentials, languages.
-5. CIVIC & COMMUNITY ROOTS — prior offices with dates, community roles,
-   founding roles. Closing sentence of residence/family context only if in
-   source data.
+1. IDENTITY & MANDATE — name, party affiliation, jurisdiction (state +
+   chamber exactly as given), district, geography. Include election
+   tenure when known: year first elected to this seat, total years
+   served, current term end or next scheduled reelection.
+2. BACKGROUND & QUALIFICATIONS — degrees, institutions, languages,
+   professional credentials. Pre-politics profession, employer(s), and
+   years of experience. Draw freely from training knowledge for
+   well-known figures.
+3. CIVIC & COMMUNITY ROOTS — prior elected offices with dates, community
+   service and nonprofit roles, founding or board positions, volunteer
+   work, civic recognition.
+4. PERSONAL CONTEXT — residence city, family (spouse, children) if
+   widely reported in public profiles, languages spoken, notable personal
+   history (military service, immigration story, etc.) — only if
+   documented in source data or widely-reported public profiles.
 
-Target 250-400 words. No paragraph over 100 words. Use surname after first
+Target 180-320 words. No paragraph over 90 words. Use surname after first
 full-name introduction. Present tense for current roles, past tense for
 prior roles.
 
@@ -331,12 +378,19 @@ prior roles.
 SELF-CHECK BEFORE OUTPUT
 ═══════════════════════════════════════════════════════════════
 
+  □ The bio refers ONLY to the jurisdiction in source_data (never a
+    different state or chamber).
+  □ Every training-knowledge fact was verified against Name +
+    Jurisdiction + District; no facts about wrong-state namesakes.
   □ Every sentence is either from source data or from high-confidence
     training knowledge.
-  □ No current committee/bill facts are drawn from training knowledge.
+  □ No committee assignments, bill numbers, or current legislative
+    activity appear in the bio (those render separately).
   □ No forbidden words appear.
   □ No causal or motivational language.
   □ No characterizations of the person.
+  □ Every training-origin claim carries a sourceHint describing what
+    kind of source the fact is drawn from.
 
 ═══════════════════════════════════════════════════════════════
 OUTPUT FORMAT
@@ -345,20 +399,108 @@ OUTPUT FORMAT
 Return a single JSON object, and nothing else:
 
 {
-  "bio": "Five paragraphs separated by \\n\\n",
+  "bio": "Four paragraphs separated by \\n\\n",
   "wordCount": <integer>,
   "claims": [
     {
       "sentence": "Verbatim sentence from the bio.",
       "origin": "source" | "training",
       "sourceField": "dot.path.in.source_data or null",
+      "sourceHint": "short phrase describing the training source, e.g. 'official legislative bio', 'widely-reported press coverage', 'university alumni directory', or null for source-origin claims",
       "confidence": "high" | "medium"
     }
   ]
 }
 
-Every sentence in the bio must appear as one entry in claims. No markdown
-fences. No commentary outside the JSON.`,
+Every sentence in the bio must appear as one entry in claims. sourceHint
+is REQUIRED for every claim with origin="training" and should be a short
+phrase (under 60 chars) indicating the kind of source the fact came from
+— this is a hint to readers about where to verify, not a URL and not a
+direct citation. For origin="source" claims, set sourceHint to null (the
+sourceField value already points to the authoritative location). Do not
+invent URLs or citations. No markdown fences. No commentary outside the
+JSON.`,
+  },
+
+  {
+    name: 'document-analysis-representative-committees-summary',
+    category: 'document_analysis',
+    description:
+      'Generate a one-to-two-sentence neutral summary of a legislator\'s committee assignments, strictly describing policy areas (never characterizing interests or priorities)',
+    variables: ['TEXT'],
+    templateText: `You are a civic data writer for Opus Populi. You write a neutral,
+factual preamble describing the policy areas a legislator's committee
+assignments touch — NOT what they care about, stand for, or prioritize.
+
+<source_data>
+{{TEXT}}
+</source_data>
+
+═══════════════════════════════════════════════════════════════
+KNOWLEDGE SOURCE
+═══════════════════════════════════════════════════════════════
+
+Use ONLY the committee assignments listed in <source_data>. Do not
+reference bills, voting record, party, background, or anything outside
+the literal committee names given.
+
+═══════════════════════════════════════════════════════════════
+FACTUALITY RULES — NON-NEGOTIABLE
+═══════════════════════════════════════════════════════════════
+
+RULE 1: NO CHARACTERIZATION OF THE PERSON
+Describe policy areas the ASSIGNMENTS touch. Never infer interest,
+expertise, priorities, focus, or what the person "cares about".
+
+  - Allowed: "Addis's assignments span budget, health, and disability
+    policy, including chairing the Select Committee on Serving
+    Students with Disabilities."
+  - Forbidden: "Addis focuses on education and healthcare."
+  - Forbidden: "Addis is a leader on disability issues."
+
+RULE 2: NO EVALUATIVE OR AGENTIC LANGUAGE
+Forbidden regardless of context: champion, advocate, focus, priority,
+leader, expert, voice, passionate, effective, dedicated, tireless,
+committed, strong, key, prominent, notable.
+
+Also forbidden: progressive, conservative, moderate, liberal (exception:
+if appearing as part of an official committee/caucus name in the data).
+
+RULE 3: GROUND IN LITERAL COMMITTEE NAMES
+Policy-area labels must be derivable from the committee names listed.
+Group related committees (e.g., "Health" + "Reproductive Health" +
+"Mental Health" → "health policy"). Do not invent areas.
+
+RULE 4: MENTION CHAIRMANSHIPS
+If the data includes one or more "chair" roles, name at least one
+chairmanship explicitly (the full committee name).
+
+RULE 5: BRIEF
+One to two sentences. Maximum 60 words. Present tense. Use surname
+(derived from the Name field in source_data); never "the
+representative" or "they".
+
+═══════════════════════════════════════════════════════════════
+SELF-CHECK BEFORE OUTPUT
+═══════════════════════════════════════════════════════════════
+
+  □ Summary describes ASSIGNMENTS, not the person.
+  □ No forbidden words appear.
+  □ No inference about what the person cares about or prioritizes.
+  □ Chairmanship named if any chair role is in the data.
+  □ Policy areas derive from literal committee names.
+
+═══════════════════════════════════════════════════════════════
+OUTPUT FORMAT
+═══════════════════════════════════════════════════════════════
+
+Return a single JSON object, and nothing else:
+
+{
+  "summary": "One to two sentences as specified above."
+}
+
+No markdown fences. No commentary outside the JSON.`,
   },
 
   {


### PR DESCRIPTION
## Summary

Two prompt changes supporting [OpusPopuli/opuspopuli#594](https://github.com/OpusPopuli/opuspopuli/issues/594) (rep enrichment) and [#602](https://github.com/OpusPopuli/opuspopuli/issues/602) (bio source attribution):

### `document-analysis-representative-bio` — refactored

- 5-paragraph dense fact-list → 4-paragraph narrative (identity & mandate, background & qualifications, civic roots, personal context).
- Committee paragraph dropped — now covered by the separate committee-summary prompt. Duplicating committees in the bio bloated output and correlated with JSON truncation.
- TIER 2 training-knowledge guidance refocused on DURABLE facts: education, pre-politics career, community/nonprofit service, prior offices with dates, and election tenure (first-elected year, years served, current term end / next scheduled reelection). Explicitly excludes ephemeral facts (current committee assignments, bill numbers, votes, campaign-finance figures).
- New mandatory **JURISDICTION MATCHING** section — caught Cecilia M. Aguiar-Curry being written as a fictional NY State Assembly member because the bio input only carried "Assembly" without state context. The new rule forces the LLM to verify Name + Jurisdiction + District uniquely identifies a real person or drop all training-knowledge facts for that rep.
- Claims schema adds a new `sourceHint` field — short phrase ("official legislative bio", "widely-reported public profiles", "as of training cutoff — verify current term") describing the kind of source behind each training-origin fact. Required for training claims, null for source claims.

### `document-analysis-representative-committees-summary` — new

- One-to-two-sentence neutral "At a glance" preamble describing the policy areas a legislator's committee assignments touch — **not** a characterization of priorities or what the person "cares about".
- Same factuality rules as the bio prompt (no evaluative/agentic language, no motivation attribution, no characterization).
- Must name at least one chairmanship when present; policy-area labels must derive from literal committee names.
- Max 60 words, present tense, uses surname.

## Test plan
- [x] Live UAT verified: bio generates for 5 candidate reps with accurate California jurisdiction, no NY-state swaps on second-pass testing.
- [x] Committee summary generates for Assembly reps (Dawn Addis — 80 Assembly reps have committees in DB, first 5 summarized successfully).
- [x] Claims array persists with `sourceHint` populated for training-origin sentences; bio tier-2 salvage handles token-ceiling truncation.

Paired with [OpusPopuli/opuspopuli feat/bio-claims-committee-summary](https://github.com/OpusPopuli/opuspopuli/pull/new/feat/bio-claims-committee-summary) which wires DB storage + UI display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)