### PR TITLE
feat(prompts): civics-extraction endpoint, template, and CVE security fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,5 +99,15 @@
   },
   "lint-staged": {
     "*.ts": "eslint --fix"
+  },
+  "pnpm": {
+    "overrides": {
+      "multer": ">=2.1.1",
+      "effect": ">=3.20.0",
+      "path-to-regexp": ">=0.1.13",
+      "defu": ">=6.1.5",
+      "lodash": ">=4.18.0",
+      "js-yaml": ">=4.1.1"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  multer: '>=2.1.1'
+  effect: '>=3.20.0'
+  path-to-regexp: '>=0.1.13'
+  defu: '>=6.1.5'
+  lodash: '>=4.18.0'
+  js-yaml: '>=4.1.1'
+
 importers:
 
   .:
@@ -936,9 +944,6 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1308,8 +1313,8 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1375,8 +1380,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.18.4:
-    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
 
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
@@ -2049,14 +2054,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -2143,11 +2140,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -2247,18 +2241,14 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp@0.5.6:
-    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
-    hasBin: true
-
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.0.2:
-    resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
 
   mute-stream@0.0.8:
@@ -2406,9 +2396,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
@@ -2708,9 +2695,6 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -3102,10 +3086,6 @@ packages:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3415,7 +3395,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.2
+      js-yaml: 4.1.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -3664,7 +3644,7 @@ snapshots:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       dotenv: 16.4.5
       dotenv-expand: 10.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       rxjs: 7.8.2
 
   '@nestjs/core@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
@@ -3698,7 +3678,7 @@ snapshots:
       body-parser: 1.20.4
       cors: 2.8.5
       express: 4.22.1
-      multer: 2.0.2
+      multer: 2.1.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -3731,8 +3711,8 @@ snapshots:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
-      js-yaml: 4.1.0
-      lodash: 4.17.21
+      js-yaml: 4.1.1
+      lodash: 4.18.1
       path-to-regexp: 3.3.0
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.17.14
@@ -3794,7 +3774,7 @@ snapshots:
     dependencies:
       c12: 3.1.0
       deepmerge-ts: 7.1.5
-      effect: 3.18.4
+      effect: 3.21.2
       empathic: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -4211,10 +4191,6 @@ snapshots:
 
   arg@4.1.3: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
@@ -4361,7 +4337,7 @@ snapshots:
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       exsolve: 1.0.8
       giget: 2.0.0
@@ -4601,7 +4577,7 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 
@@ -4648,7 +4624,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.18.4:
+  effect@3.21.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
@@ -4845,7 +4821,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 3.3.0
       proxy-addr: 2.0.7
       qs: 6.14.2
       range-parser: 1.2.1
@@ -5040,7 +5016,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.6.5
       pathe: 2.0.3
@@ -5168,7 +5144,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -5187,7 +5163,7 @@ snapshots:
       cli-width: 4.1.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       mute-stream: 1.0.0
       ora: 5.4.1
       run-async: 3.0.0
@@ -5602,15 +5578,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -5687,9 +5654,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
-
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -5771,23 +5736,16 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
-
   ms@2.0.0: {}
 
   ms@2.1.3: {}
 
-  multer@2.0.2:
+  multer@2.1.1:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
       concat-stream: 2.0.0
-      mkdirp: 0.5.6
-      object-assign: 4.1.1
       type-is: 1.6.18
-      xtend: 4.0.2
 
   mute-stream@0.0.8: {}
 
@@ -5803,7 +5761,7 @@ snapshots:
 
   node-emoji@1.11.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   node-fetch-native@1.6.7: {}
 
@@ -5918,8 +5876,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-to-regexp@0.1.12: {}
-
   path-to-regexp@3.3.0: {}
 
   path-type@4.0.0: {}
@@ -6012,7 +5968,7 @@ snapshots:
 
   rc9@2.1.2:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
 
   react-is@18.3.1: {}
@@ -6215,8 +6171,6 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
-
-  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -6593,8 +6547,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-
-  xtend@4.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -431,7 +431,7 @@ JSON.`,
     name: 'document-analysis-representative-committees-summary',
     category: 'document_analysis',
     description:
-      'Generate a one-to-two-sentence neutral summary of a legislator\'s committee assignments, strictly describing policy areas (never characterizing interests or priorities)',
+      "Generate a one-to-two-sentence neutral summary of a legislator's committee assignments, strictly describing policy areas (never characterizing interests or priorities)",
     variables: ['TEXT'],
     templateText: `You are a civic data writer for Opus Populi. You write a neutral,
 factual preamble describing the policy areas a legislator's committee
@@ -512,7 +512,7 @@ No markdown fences. No commentary outside the JSON.`,
     name: 'document-analysis-legislative-committee-description',
     category: 'document_analysis',
     description:
-      "Generate a 2-3 sentence neutral, voter-friendly description of what a state legislative committee does, given its chamber and name. Output JSON: { description: string }.",
+      'Generate a 2-3 sentence neutral, voter-friendly description of what a state legislative committee does, given its chamber and name. Output JSON: { description: string }.',
     variables: ['TEXT'],
     templateText: `You are a civic data writer for Opus Populi. You write a neutral,
 factual description of what a state legislative committee does, aimed at
@@ -851,7 +851,7 @@ Answer:`,
     name: 'civics-extraction',
     category: 'civics_extraction',
     description:
-      'Extract a structured CivicsBlock (chambers, measure types, lifecycle stages with status patterns, glossary, sessionScheme) from an official government page describing how a region\'s legislature works. Every text field carries BOTH the verbatim source text AND a plain-language rewrite for laypeople.',
+      "Extract a structured CivicsBlock (chambers, measure types, lifecycle stages with status patterns, glossary, sessionScheme) from an official government page describing how a region's legislature works. Every text field carries BOTH the verbatim source text AND a plain-language rewrite for laypeople.",
     variables: [
       'REGION_ID',
       'SOURCE_URL',
@@ -1051,7 +1051,11 @@ function hash(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
-async function upsertVaultSecret(name: string, key: string, description: string) {
+async function upsertVaultSecret(
+  name: string,
+  key: string,
+  description: string,
+) {
   try {
     const existing = await prisma.$queryRaw<{ id: string }[]>`
       SELECT id::text FROM vault.decrypted_secrets WHERE name = ${name}
@@ -1079,18 +1083,32 @@ async function seedVaultKeys() {
   console.log('\nSeeding Vault keys...');
 
   const apiKeys = process.env.API_KEYS ?? '';
-  const regionEntries = apiKeys.split(',').map((e) => e.trim()).filter(Boolean);
+  const regionEntries = apiKeys
+    .split(',')
+    .map((e) => e.trim())
+    .filter(Boolean);
 
   for (const entry of regionEntries) {
     const { region, key } = parseRegionEntry(entry);
-    await upsertVaultSecret(`region_key_${region}`, key, `Region API key for ${region}`);
+    await upsertVaultSecret(
+      `region_key_${region}`,
+      key,
+      `Region API key for ${region}`,
+    );
   }
 
   const adminKeys = process.env.ADMIN_API_KEYS ?? '';
-  const adminEntries = adminKeys.split(',').map((k) => k.trim()).filter(Boolean);
+  const adminEntries = adminKeys
+    .split(',')
+    .map((k) => k.trim())
+    .filter(Boolean);
 
   for (let i = 0; i < adminEntries.length; i++) {
-    await upsertVaultSecret(`admin_key_${i + 1}`, adminEntries[i], `Admin API key ${i + 1}`);
+    await upsertVaultSecret(
+      `admin_key_${i + 1}`,
+      adminEntries[i],
+      `Admin API key ${i + 1}`,
+    );
   }
 }
 

--- a/test/integration/prompts/civics-extraction.integration.spec.ts
+++ b/test/integration/prompts/civics-extraction.integration.spec.ts
@@ -25,7 +25,9 @@ describe('Civics Extraction Prompt (integration)', () => {
     expect(res.body.promptText).toContain(BASE_PAYLOAD.contentGoal);
     expect(res.body.promptText).toContain('Category: Assembly');
     expect(res.body.promptText).toContain('- ~150 terms organized A-Z');
-    expect(res.body.promptText).toContain('Engrossed: proofread after amendment.');
+    expect(res.body.promptText).toContain(
+      'Engrossed: proofread after amendment.',
+    );
     expect(res.body.promptHash).toMatch(/^[a-f0-9]{64}$/);
     expect(res.body.promptVersion).toMatch(/^v\d+$/);
     expect(res.body.expiresAt).toBeDefined();


### PR DESCRIPTION
## Summary

Adds the `civics-extraction` prompt endpoint and template (issue #669), completes pre-push guardrails, and patches 7 HIGH-severity transitive CVEs.

### What changed

**New: `POST /prompts/civics-extraction`**
- New `CivicsExtractionDto` with `regionId`, `sourceUrl`, `contentGoal`, `html` (required), plus optional `category` and `hints`
- New `getCivicsExtractionPrompt()` service method — resolves the `civics-extraction` template and interpolates all six variables
- Rate-limited at 30 req/min per key (consistent with other prompt endpoints)
- Full Swagger docs and Postman collection request included

**New: `civics-extraction` prompt template**
- Seeded in `prisma/seed.ts` as `v1` — instructs the LLM to emit a `CivicsBlock` with verbatim source text + plain-language rewrites for every text field
- Integration test in `test/integration/prompts/civics-extraction.integration.spec.ts` verifies rendered prompt content, hash format, and version format

**Security: 7 HIGH CVEs patched via `pnpm.overrides`**
- `multer >=2.1.1` — 3x DoS CVEs (GHSA-xf7r, GHSA-v52c, GHSA-5528)
- `effect >=3.20.0` — AsyncLocalStorage context contamination (CVE-2026-32887)
- `path-to-regexp >=0.1.13` — ReDoS (CVE-2026-4867)
- `defu >=6.1.5` — prototype pollution (CVE-2026-35209)
- `lodash >=4.18.0` — arbitrary code execution in template imports (CVE-2026-4800) → resolved to `4.18.1`
- `js-yaml >=4.1.1` — prototype pollution (GHSA-mh29-5h37-fv8m)

**Guardrails and housekeeping**
- `husky` pre-commit (lint-staged) and pre-push (coverage threshold + AI security gate) hooks
- Dockerfile fixed for pnpm v10+ `--ignore-scripts` requirement
- SonarCloud removed (replaced by local coverage thresholds + husky gate)
- CLAUDE.md added for Claude Code context

### What was NOT changed
- No DB schema changes (Prisma schema has a cosmetic datasource comment fix only — no migration needed)
- No breaking changes to existing endpoints
- 3 moderate CVEs intentionally deferred: `file-type` (ESM incompatibility blocks safe override), `@nestjs/core` (requires NestJS v11 major upgrade — tracked separately)

## How to test

**Unit tests:**
```bash
pnpm test
```

**Integration test (Docker required):**
```bash
pnpm integration:up
pnpm test:integration -- --testPathPattern civics-extraction
pnpm integration:down
```

**Manual smoke test:**
```bash
# Start the service
docker compose up -d

# Health check — expect 17 active templates
curl http://localhost:3210/health

# Civics extraction
curl -X POST http://localhost:3210/prompts/civics-extraction \
  -H "Authorization: Bearer dev-key-1" \
  -H "Content-Type: application/json" \
  -d '{
    "regionId": "california",
    "sourceUrl": "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml",
    "contentGoal": "Extract CivicsBlock for California Assembly legislative process",
    "category": "Assembly",
    "html": "<html>...</html>"
  }'
```

Expected response: `{ promptText, promptHash, promptVersion, expiresAt }`

## Linked issues

- Closes OpusPopuli/opuspopuli#669 (civics-extraction contract)
- Related: OpusPopuli/opuspopuli-regions#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)