### PR TITLE
chore(infra): harden docker setup with resource limits and healthchecks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,6 +36,3 @@ scripts
 # Supabase init scripts (volume-mounted in compose, not used by Prisma migrations)
 supabase
 
-# Test files (unit tests only — test/ is needed by Dockerfile.test-runner)
-**/*.spec.ts
-**/*.e2e-spec.ts

--- a/.dockerignore
+++ b/.dockerignore
@@ -36,7 +36,6 @@ scripts
 # Supabase init scripts (volume-mounted in compose, not used by Prisma migrations)
 supabase
 
-# Test files
-test
+# Test files (unit tests only — test/ is needed by Dockerfile.test-runner)
 **/*.spec.ts
 **/*.e2e-spec.ts

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,42 @@
+# Dependencies and build output
 node_modules
 dist
 coverage
+
+# Environment files
 .env
 .env.local
+.env.*.local
+
+# Version control and tooling
 .git
+.github
+.husky
+.claude
+.vscode
+
+# Linting, formatting, and code quality config
+.eslintrc*
+.prettierrc*
+.jscpd.json
+.gitleaks.toml
+
+# Documentation
+*.md
+docs
+
+# Docker files (not needed inside the image)
+Dockerfile*
+docker-compose*.yml
+
+# Dev and CI tooling
+postman
+scripts
+
+# Supabase init scripts (volume-mounted in compose, not used by Prisma migrations)
+supabase
+
+# Test files
+test
+**/*.spec.ts
+**/*.e2e-spec.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY --from=builder /app/prisma ./prisma
 COPY package.json ./
 
 EXPOSE 3200
-CMD ["sh", "-c", "pnpm db:migrate:deploy && node dist/seed/seed.js && node dist/main"]
+CMD ["sh", "-c", "node_modules/.bin/prisma migrate deploy && node dist/seed/seed.js && node dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,16 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   opuspopuli-prompts:
     build: .
@@ -34,6 +44,21 @@ services:
     depends_on:
       opuspopuli-prompts-db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3210/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 256M
 
 volumes:
   opuspopuli-prompts-db-data:


### PR DESCRIPTION
## Summary

- Fix OOM crash on every container restart caused by pnpm v10+ supply-chain lockfile verification running in the 512M-limited container at startup — bypassed by calling `node_modules/.bin/prisma migrate deploy` directly instead of going through `pnpm`
- Add resource limits (512M), restart policies, and `start_period` to both `opuspopuli-prompts` and `opuspopuli-prompts-db`
- Add `/health`-based healthcheck to `opuspopuli-prompts` so orchestrators can detect actual readiness post-migration and seed
- Expand `.dockerignore` to exclude `.claude/` (493MB worktrees), test files, tooling config, and other noise from the build context

## Test plan

- [ ] `docker compose up -d --build --force-recreate` completes without OOM
- [ ] `docker ps` shows both containers `(healthy)` within 30s of start
- [ ] `curl http://localhost:3210/health` returns 200
- [ ] `docker compose down && docker compose up -d --build --force-recreate` confirms restart policy recovers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)