### PR TITLE
feat(common): structured logging, correlation IDs, and Prometheus metrics (#27)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ coverage/
 .env
 .env.local
 *.tsbuildinfo
+
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ The client implements a 3-tier fallback so nodes degrade gracefully if this serv
 | `rag` | Retrieval-augmented generation (citizen Q&A) |
 | `civics_extraction` | Structured civic-process data extraction (`CivicsBlock` — chambers, measure types, lifecycle stages, glossary) |
 | `bill_extraction` | Legislative bill and vote record extraction |
+| `bill_votes_extraction` | Chamber-level roll-call vote records (per-member positions) from a bill votes page |
 
 Template names follow the pattern `{category}-{document-type}` or just `{category}` for single-template categories, e.g. `document-analysis-petition`, `civics-extraction`, `bill-extraction`, `bill-votes-extraction`.
 
@@ -85,11 +86,11 @@ Registered nodes authenticate with **HMAC-SHA256** request signing:
 
 Requests expire after 5 minutes (replay protection). The `@opuspopuli/prompt-client` handles signing automatically when `hmacNodeId` is configured.
 
-Admin endpoints use a separate `ADMIN_API_KEY` (Bearer token). Never expose the admin key to nodes.
+Admin endpoints use a separate `ADMIN_API_KEYS` env var (comma-separated Bearer tokens). Never expose the admin key to nodes.
 
 ## A/B experiments
 
-Experiments in the `experiments` table test prompt variants against a control. The `ExperimentsModule` handles bucketing deterministically by node ID. When adding a new template variant, create the experiment via the admin API — do not manually edit the DB.
+Experiments in the `experiments` table test prompt variants against a control. The `ExperimentsModule` handles bucketing deterministically by API key (SHA-256 of `apiKey + experimentId` mod 100). Note: key rotation reassigns a node's bucket — keep this in mind when designing long-running experiments. When adding a new template variant, create the experiment via the admin API — do not manually edit the DB.
 
 ## IP boundary
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Base URL: `http://localhost:3200` (development) or configured deployment URL.
+Base URL: `http://localhost:3210` (development) or configured deployment URL.
 
 Interactive Swagger UI available at `/api`.
 
@@ -100,6 +100,8 @@ Admin endpoints (`/admin/*`) use a separate set of API keys configured via the `
 Authorization: Bearer <ADMIN_API_KEY>
 ```
 
+Every response includes an `X-Correlation-Id` response header (HTTP headers are case-insensitive; the service emits lowercase `x-correlation-id`). Pass this ID when reporting issues — it ties all log lines for a request together.
+
 ## Rate Limits
 
 | Scope | Limit | Window |
@@ -116,23 +118,54 @@ When exceeded, returns `429 Too Many Requests`.
 
 Health check endpoint. No authentication required.
 
-### Response
+### Response (healthy — HTTP 200)
 
 ```json
 {
   "status": "ok",
   "timestamp": "2025-02-25T12:00:00.000Z",
   "database": "connected",
-  "activeTemplates": 21
+  "activeTemplates": 21,
+  "auditLogFailures": 0
+}
+```
+
+### Response (degraded — HTTP 503)
+
+```json
+{
+  "status": "error",
+  "timestamp": "2025-02-25T12:00:00.000Z",
+  "database": "disconnected",
+  "detail": "Can't reach database server at ...",
+  "auditLogFailures": 0
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | `"ok"` \| `"degraded"` | `"degraded"` when database is unreachable |
+| `status` | `"ok"` \| `"error"` | `"error"` when database is unreachable |
 | `timestamp` | string | ISO 8601 timestamp |
 | `database` | `"connected"` \| `"disconnected"` | Database connectivity |
-| `activeTemplates` | number | Count of active templates (0 if DB is down) |
+| `activeTemplates` | number | Count of active templates; present only when healthy |
+| `detail` | string | First line of DB error message; present only when degraded |
+| `auditLogFailures` | number | Audit log write failures since last restart (non-zero = investigate) |
+
+---
+
+## `GET /metrics`
+
+Prometheus metrics endpoint. No authentication required (private network only — not exposed publicly).
+
+Scraped by Prometheus at the configured scrape interval. Key metrics:
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `prompt_service_requests_total` | Counter | `endpoint`, `method`, `status` | Total HTTP requests processed |
+| `prompt_service_request_duration_seconds` | Histogram | `endpoint`, `method` | Request duration in seconds |
+| `process_*`, `nodejs_*` | Various | — | Default Node.js + process metrics |
+
+Path parameters are normalised to avoid high cardinality (e.g., `/prompts/:name/hash` rather than the literal template name; UUIDs replaced with `:id`).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,9 @@ AppModule
 ├── ThrottlerModule (global)        # Rate limiting: 60 req/min default
 ├── PrismaModule (global)           # Database connection lifecycle
 ├── ExperimentsModule (global)      # A/B testing bucketing engine
+├── MetricsModule                   # Prometheus metrics + HTTP interceptor
+│   └── HttpMetricsInterceptor      # APP_INTERCEPTOR — records latency + counts per endpoint
+├── CorrelationMiddleware           # Generates/propagates correlationId for every request
 ├── HealthModule                    # GET /health
 ├── PromptsModule                   # Prompt serving endpoints
 │   ├── PromptsController           # Route handlers + node API key guards
@@ -51,6 +54,8 @@ AppModule
 └── AdminModule                     # Template & experiment management
     ├── AdminController             # CRUD for templates (admin key auth)
     ├── ExperimentsAdminController  # Experiment lifecycle (admin key auth)
+    ├── NodeRegistryController      # Node lifecycle: register, certify, decertify, rotate key
+    ├── NodeRegistryService         # Node CRUD + Vault key storage
     └── AdminService                # Template CRUD, rollback, experiment management
 ```
 
@@ -64,7 +69,7 @@ Primary storage for prompt templates. Each template has a unique name and belong
 |--------|------|-------------|
 | `id` | UUID | Primary key |
 | `name` | String (unique) | Template identifier (e.g., `document-analysis-petition`) |
-| `category` | String | `structural_analysis`, `document_analysis`, `rag`, `civics_extraction`, or `bill_extraction` |
+| `category` | String | `structural_analysis`, `document_analysis`, `rag`, `civics_extraction`, `bill_extraction`, or `bill_votes_extraction` |
 | `description` | String | Human-readable purpose |
 | `template_text` | Text | Template with `{{VARIABLE}}` placeholders |
 | `variables` | String[] | List of expected variable names |
@@ -114,6 +119,39 @@ Variant definitions within an experiment. Traffic percentages must sum to 100.
 | `version_id` | UUID | FK to `prompt_version_history` — which template version to serve |
 | `traffic_pct` | Int | Traffic percentage (0-100) |
 
+### `nodes`
+
+Registered client nodes that authenticate via HMAC or Bearer token.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key (also used as `X-HMAC-Key-Id`) |
+| `name` | String | Human-readable node name |
+| `region` | String | Region identifier (attached to all prompt requests from this node) |
+| `public_key` | String? | Optional public key for future asymmetric auth |
+| `api_key` | String | Plaintext API key (also stored in Vault) |
+| `api_key_hash` | String | SHA-256 hash used for fast Bearer token lookups |
+| `api_key_secret_id` | String? | Vault secret ID for the plaintext key (used in HMAC path) |
+| `status` | String | `pending`, `certified`, or `decertified` |
+| `certified_at` | Timestamptz? | When the node was last certified |
+| `certification_expires_at` | Timestamptz? | Certification expiry — node is blocked after this |
+| `decertified_at` | Timestamptz? | When the node was decertified |
+| `created_at` | Timestamptz | Registration timestamp |
+| `updated_at` | Timestamptz | Last modification timestamp |
+
+### `node_audit_logs`
+
+Immutable record of every node state change (certification, decertification, key rotation).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID | Primary key |
+| `node_id` | UUID | FK to `nodes` |
+| `action` | String | `registered`, `certified`, `decertified`, `recertified`, `key_rotated` |
+| `reason` | String? | Admin-provided reason |
+| `performed_by` | String | First 8 chars of the admin key used to perform the action |
+| `created_at` | Timestamptz | When the action occurred |
+
 ### `prompt_request_logs`
 
 Analytics table tracking prompt usage, including A/B experiment participation.
@@ -138,8 +176,14 @@ Analytics table tracking prompt usage, including A/B experiment participation.
    Headers: Authorization: Bearer <API_KEY>
    Body: { documentType: "petition", text: "..." }
 
+1a. CorrelationMiddleware: reads X-Correlation-Id header or generates a UUID.
+    Stores in AsyncLocalStorage so all log lines for this request share the ID.
+    Echoes X-Correlation-Id in the response.
+
+1b. HttpMetricsInterceptor: records start time; increments counter + histogram on completion.
+
 2. ApiKeyGuard validates Bearer token against API_KEYS env var
-   → 401 if invalid
+   → 401 if invalid (logs structured auth_failed event)
 
 3. ThrottlerGuard checks rate limit (30 req/min for prompt endpoints)
    → 429 if exceeded
@@ -253,6 +297,40 @@ draft → active → stopped
 - **Only primary templates are A/B tested**: Auxiliary templates (schema descriptions, base instructions) always use the default version. This keeps prompt composition predictable.
 - **Separate admin controller**: Experiment endpoints use `/admin/experiments` (not nested under `/admin/templates/:id`) to avoid route parameter conflicts.
 - **No auto-winner selection**: Experiments must be manually stopped and evaluated. Automatic winner selection is out of scope for the initial implementation.
+
+## Observability
+
+### Correlation IDs
+
+Every HTTP request gets a `correlationId` (UUID v4) generated by `CorrelationMiddleware` and stored in `AsyncLocalStorage`. All structured log lines produced during the request lifecycle include this ID. The ID is also echoed back to the caller as `X-Correlation-Id`.
+
+Pass an `X-Correlation-Id` header to propagate an existing ID (e.g., from an upstream service) instead of generating a new one.
+
+### Structured Logging
+
+`StructuredLoggerService` (the app-wide logger) outputs JSON in production and colourised pretty-print in development. Every line includes `{ timestamp, level, service, message, correlationId?, nodeId?, endpoint? }`.
+
+Key structured events emitted by the service (grepping by `event` field):
+
+| Event | Where | Fields |
+|-------|-------|--------|
+| `auth_failed` | `ApiKeyGuard` | `method` (bearer/hmac), `reason`, `keyId` (HMAC only) |
+| `vault_write_failed` | `NodeRegistryService` | `action`, `nodeId`, `error` |
+| `audit_log_write_failure` | `PromptsService` | `endpoint`, `region`, `apiKeyPrefix`, `cumulativeFailures`, `error` |
+| `node_registered` | `NodeRegistryService` | `nodeId`, `region`, `performedBy` |
+| `node_certified` / `node_decertified` / `node_recertified` / `node_key_rotated` | `NodeRegistryService` | `nodeId`, `performedBy` |
+| `experiment_variant_assigned` | `ExperimentsService` | `templateName`, `experimentId`, `variantName`, `apiKeyPrefix` |
+
+### Prometheus Metrics
+
+`MetricsModule` registers two custom metrics via `@willsoto/nestjs-prometheus`:
+
+- **`prompt_service_requests_total`** (Counter) — labels: `endpoint`, `method`, `status`
+- **`prompt_service_request_duration_seconds`** (Histogram) — labels: `endpoint`, `method`; buckets from 5ms to 5s
+
+`HttpMetricsInterceptor` is applied globally as `APP_INTERCEPTOR` and also stamps `endpoint` into the current request's correlation store so log lines carry it.
+
+`GET /metrics` is served by `PrometheusModule` without authentication (private Docker network only).
 
 Note: The `prompt-client` in the main repo has its own 3-tier fallback:
 1. Remote service (this service) → 2. Local database → 3. Hardcoded fallbacks

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
     "@nestjs/swagger": "^7.4.0",
     "@nestjs/throttler": "^6.3.0",
     "@prisma/client": "^6.2.1",
+    "@willsoto/nestjs-prometheus": "^6.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -83,7 +85,8 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s",
       "!**/*.module.ts",
-      "!**/main.ts"
+      "!**/main.ts",
+      "!**/correlation.storage.ts"
     ],
     "coverageDirectory": "../coverage",
     "coverageReporters": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,12 +37,18 @@ importers:
       '@prisma/client':
         specifier: ^6.2.1
         version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
+      '@willsoto/nestjs-prometheus':
+        specifier: ^6.1.0
+        version: 6.1.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
       class-validator:
         specifier: ^0.14.3
         version: 0.14.3
+      prom-client:
+        specifier: ^15.1.3
+        version: 15.1.3
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -607,6 +613,10 @@ packages:
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -875,6 +885,12 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@willsoto/nestjs-prometheus@6.1.0':
+    resolution: {integrity: sha512-lrCEnJBBSzUIYWGR+PsZw1YXs1B9jzxFEuNAa3RzTxuFAFdI+sW7Fp52il/U/dX2MWoHc32x06OS0nm56QwyzQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      prom-client: ^15.0.0
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -1045,6 +1061,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bintrees@1.0.2:
+    resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -2586,6 +2605,10 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  prom-client@15.1.3:
+    resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
+    engines: {node: ^16 || ^18 || >=20}
+
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -2958,6 +2981,9 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tdigest@0.1.2:
+    resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -3962,6 +3988,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -4311,6 +4339,11 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@willsoto/nestjs-prometheus@6.1.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(prom-client@15.1.3)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      prom-client: 15.1.3
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -4485,6 +4518,8 @@ snapshots:
   baseline-browser-mapping@2.10.0: {}
 
   binary-extensions@2.3.0: {}
+
+  bintrees@1.0.2: {}
 
   bl@4.1.0:
     dependencies:
@@ -6249,6 +6284,11 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  prom-client@15.1.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      tdigest: 0.1.2
+
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -6671,6 +6711,10 @@ snapshots:
       '@pkgr/core': 0.2.9
 
   tapable@2.3.0: {}
+
+  tdigest@0.1.2:
+    dependencies:
+      bintrees: 1.0.2
 
   terser-webpack-plugin@5.3.16(webpack@5.97.1):
     dependencies:

--- a/postman/prompt-service.postman_collection.json
+++ b/postman/prompt-service.postman_collection.json
@@ -5,7 +5,7 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
-    { "key": "baseUrl", "value": "http://localhost:3200" },
+    { "key": "baseUrl", "value": "http://localhost:3210" },
     { "key": "apiKey", "value": "dev-key-1" },
     { "key": "adminKey", "value": "admin-dev-key-1" },
     { "key": "templateId", "value": "" },
@@ -30,6 +30,10 @@
                   "  const body = pm.response.json();",
                   "  pm.expect(body.database).to.eql('connected');",
                   "  pm.expect(body.activeTemplates).to.be.above(0);",
+                  "  pm.expect(body).to.have.property('auditLogFailures');",
+                  "});",
+                  "pm.test('X-Correlation-Id header present', () => {",
+                  "  pm.expect(pm.response.headers.get('x-correlation-id')).to.be.a('string').and.not.empty;",
                   "});"
                 ]
               }
@@ -234,6 +238,102 @@
               "path": ["prompts", "structural-analysis", "hash"]
             },
             "description": "Returns the current SHA-256 hash and version of a named template with no interpolation. Used by clients to cheaply check whether a cached prompt is stale without fetching the full rendered prompt. Authoritative source of truth for manifest cache invalidation."
+          }
+        },
+        {
+          "name": "Bill Extraction",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "  pm.expect(body).to.have.property('promptVersion');",
+                  "  pm.expect(body).to.have.property('expiresAt');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{apiKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionId\": \"california\",\n  \"sourceUrl\": \"https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml?bill_id=202520260AB1\",\n  \"sessionYear\": \"2025-2026\",\n  \"html\": \"<html><body><h1>AB 1</h1><p>An act to amend Section 1 of the Education Code...</p></body></html>\"\n}"
+            },
+            "description": "Bill-extraction prompt — LLM returns a structured Bill record including authors, co-authors, subjects, and vote history from a single official legislature bill status page. See OpusPopuli/opuspopuli#686.",
+            "url": { "raw": "{{baseUrl}}/prompts/bill-extraction", "host": ["{{baseUrl}}"], "path": ["prompts", "bill-extraction"] }
+          }
+        },
+        {
+          "name": "Bill Votes Extraction",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "  pm.expect(body).to.have.property('promptVersion');",
+                  "  pm.expect(body).to.have.property('expiresAt');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{apiKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionId\": \"california\",\n  \"sourceUrl\": \"https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=202520260AB1\",\n  \"sessionYear\": \"2025-2026\",\n  \"billId\": \"202520260AB1\",\n  \"html\": \"<html><body><h2>Assembly Floor Vote</h2><table><tr><td>AYES</td><td>Smith</td></tr></table></body></html>\"\n}"
+            },
+            "description": "Bill-votes-extraction prompt — LLM returns structured chamber-level roll-call vote records (per-member positions) from a bill votes page. Companion to bill-extraction; votes are always extracted in a separate call. See OpusPopuli/opuspopuli#686.",
+            "url": { "raw": "{{baseUrl}}/prompts/bill-votes-extraction", "host": ["{{baseUrl}}"], "path": ["prompts", "bill-votes-extraction"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Observability",
+      "description": "Prometheus metrics endpoint. No authentication required.",
+      "item": [
+        {
+          "name": "Metrics",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Contains prompt_service metrics', () => {",
+                  "  const text = pm.response.text();",
+                  "  pm.expect(text).to.include('prompt_service_requests_total');",
+                  "  pm.expect(text).to.include('prompt_service_request_duration_seconds');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": { "raw": "{{baseUrl}}/metrics", "host": ["{{baseUrl}}"], "path": ["metrics"] },
+            "description": "Prometheus metrics scrape endpoint. Returns all default Node.js process metrics plus:\n- `prompt_service_requests_total` (counter, labels: endpoint, method, status)\n- `prompt_service_request_duration_seconds` (histogram, labels: endpoint, method)\n\nEndpoint labels are normalized: UUIDs and numeric path segments are replaced with `:id`."
           }
         }
       ]
@@ -614,7 +714,10 @@
                   "pm.test('Status is 200', () => pm.response.to.have.status(200));",
                   "pm.test('Has dashboard metrics', () => {",
                   "  const body = pm.response.json();",
-                  "  pm.expect(body).to.have.property('total');",
+                  "  pm.expect(body).to.have.property('totalNodes');",
+                  "  pm.expect(body).to.have.property('byStatus');",
+                  "  pm.expect(body).to.have.property('expiringIn30Days');",
+                  "  pm.expect(body).to.have.property('recentlyRegistered');",
                   "});"
                 ]
               }
@@ -1016,6 +1119,114 @@
               "raw": "{\n  \"documentType\": \"petition\",\n  \"text\": \"We, the undersigned residents of California, hereby petition the state legislature to allocate additional funding for public transit.\"\n}"
             },
             "url": { "raw": "{{baseUrl}}/prompts/document-analysis", "host": ["{{baseUrl}}"], "path": ["prompts", "document-analysis"] }
+          }
+        },
+        {
+          "name": "Bill Extraction (HMAC)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const apiKey = pm.collectionVariables.get('nodeApiKey') || pm.environment.get('nodeApiKey') || pm.variables.get('nodeApiKey');",
+                  "const nodeId = pm.collectionVariables.get('nodeId') || pm.environment.get('nodeId') || pm.variables.get('nodeId');",
+                  "",
+                  "if (!apiKey || !nodeId) {",
+                  "  throw new Error('nodeApiKey or nodeId not set. Run Register Node + Certify Node first.');",
+                  "}",
+                  "",
+                  "const timestamp = Math.floor(Date.now() / 1000).toString();",
+                  "const method = pm.request.method;",
+                  "const path = '/' + pm.request.url.path.join('/');",
+                  "const body = pm.request.body ? pm.request.body.raw : '';",
+                  "const bodyHash = CryptoJS.SHA256(body).toString();",
+                  "const signatureString = timestamp + '\\n' + method + '\\n' + path + '\\n' + bodyHash;",
+                  "const signature = CryptoJS.HmacSHA256(signatureString, apiKey).toString(CryptoJS.enc.Base64);",
+                  "",
+                  "pm.request.headers.add({ key: 'X-HMAC-Signature', value: signature });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Timestamp', value: timestamp });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Key-Id', value: nodeId });"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionId\": \"california\",\n  \"sourceUrl\": \"https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml?bill_id=202520260AB1\",\n  \"sessionYear\": \"2025-2026\",\n  \"html\": \"<html><body><h1>AB 1</h1><p>An act to amend Section 1 of the Education Code...</p></body></html>\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/prompts/bill-extraction", "host": ["{{baseUrl}}"], "path": ["prompts", "bill-extraction"] }
+          }
+        },
+        {
+          "name": "Bill Votes Extraction (HMAC)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const apiKey = pm.collectionVariables.get('nodeApiKey') || pm.environment.get('nodeApiKey') || pm.variables.get('nodeApiKey');",
+                  "const nodeId = pm.collectionVariables.get('nodeId') || pm.environment.get('nodeId') || pm.variables.get('nodeId');",
+                  "",
+                  "if (!apiKey || !nodeId) {",
+                  "  throw new Error('nodeApiKey or nodeId not set. Run Register Node + Certify Node first.');",
+                  "}",
+                  "",
+                  "const timestamp = Math.floor(Date.now() / 1000).toString();",
+                  "const method = pm.request.method;",
+                  "const path = '/' + pm.request.url.path.join('/');",
+                  "const body = pm.request.body ? pm.request.body.raw : '';",
+                  "const bodyHash = CryptoJS.SHA256(body).toString();",
+                  "const signatureString = timestamp + '\\n' + method + '\\n' + path + '\\n' + bodyHash;",
+                  "const signature = CryptoJS.HmacSHA256(signatureString, apiKey).toString(CryptoJS.enc.Base64);",
+                  "",
+                  "pm.request.headers.add({ key: 'X-HMAC-Signature', value: signature });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Timestamp', value: timestamp });",
+                  "pm.request.headers.add({ key: 'X-HMAC-Key-Id', value: nodeId });"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('Status is 200', () => pm.response.to.have.status(200));",
+                  "pm.test('Response has required fields', () => {",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body).to.have.property('promptText');",
+                  "  pm.expect(body).to.have.property('promptHash');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionId\": \"california\",\n  \"sourceUrl\": \"https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=202520260AB1\",\n  \"sessionYear\": \"2025-2026\",\n  \"billId\": \"202520260AB1\",\n  \"html\": \"<html><body><h2>Assembly Floor Vote</h2><table><tr><td>AYES</td><td>Smith</td></tr></table></body></html>\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/prompts/bill-votes-extraction", "host": ["{{baseUrl}}"], "path": ["prompts", "bill-votes-extraction"] }
           }
         }
       ]

--- a/postman/prompt-service.postman_environment.json
+++ b/postman/prompt-service.postman_environment.json
@@ -4,7 +4,7 @@
   "values": [
     {
       "key": "baseUrl",
-      "value": "http://localhost:3200",
+      "value": "http://localhost:3210",
       "type": "default",
       "enabled": true
     },

--- a/src/admin/node-registry.service.ts
+++ b/src/admin/node-registry.service.ts
@@ -85,11 +85,20 @@ export class NodeRegistryService {
         data: { apiKeySecretId: secretId },
       });
     } catch (error) {
-      this.logger.warn(
-        `Failed to store API key in Vault for node ${node.id}: ${error}`,
-      );
+      this.logger.warn({
+        event: 'vault_write_failed',
+        action: 'store_api_key',
+        nodeId: node.id,
+        error: (error as Error).message,
+      });
     }
 
+    this.logger.log({
+      event: 'node_registered',
+      nodeId: node.id,
+      region: node.region,
+      performedBy: adminKeyPrefix,
+    });
     return node;
   }
 
@@ -153,6 +162,11 @@ export class NodeRegistryService {
         },
       });
 
+      this.logger.log({
+        event: 'node_certified',
+        nodeId: id,
+        performedBy: adminKeyPrefix,
+      });
       return updated;
     });
   }
@@ -182,6 +196,11 @@ export class NodeRegistryService {
         },
       });
 
+      this.logger.log({
+        event: 'node_decertified',
+        nodeId: id,
+        performedBy: adminKeyPrefix,
+      });
       return updated;
     });
   }
@@ -209,6 +228,11 @@ export class NodeRegistryService {
         },
       });
 
+      this.logger.log({
+        event: 'node_recertified',
+        nodeId: id,
+        performedBy: adminKeyPrefix,
+      });
       return updated;
     });
   }
@@ -254,11 +278,19 @@ export class NodeRegistryService {
         data: { apiKeySecretId: secretId },
       });
     } catch (error) {
-      this.logger.warn(
-        `Failed to update Vault for key rotation on node ${id}: ${error}`,
-      );
+      this.logger.warn({
+        event: 'vault_write_failed',
+        action: 'rotate_api_key',
+        nodeId: id,
+        error: (error as Error).message,
+      });
     }
 
+    this.logger.log({
+      event: 'node_key_rotated',
+      nodeId: id,
+      performedBy: adminKeyPrefix,
+    });
     return node;
   }
 
@@ -272,9 +304,12 @@ export class NodeRegistryService {
       try {
         await this.vault.deleteSecret(node.apiKeySecretId);
       } catch (error) {
-        this.logger.warn(
-          `Failed to delete Vault secret for node ${id}: ${error}`,
-        );
+        this.logger.warn({
+          event: 'vault_write_failed',
+          action: 'delete_secret',
+          nodeId: id,
+          error: (error as Error).message,
+        });
       }
     }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,11 +1,13 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from './common/prisma.module';
+import { CorrelationMiddleware } from './common/correlation.middleware';
 import { HealthModule } from './health/health.module';
 import { PromptsModule } from './prompts/prompts.module';
 import { AdminModule } from './admin/admin.module';
 import { ExperimentsModule } from './experiments/experiments.module';
+import { MetricsModule } from './metrics/metrics.module';
 
 @Module({
   imports: [
@@ -16,6 +18,11 @@ import { ExperimentsModule } from './experiments/experiments.module';
     PromptsModule,
     AdminModule,
     ExperimentsModule,
+    MetricsModule,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(CorrelationMiddleware).forRoutes('*');
+  }
+}

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -111,6 +111,11 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
       return true;
     }
 
+    this.logger.warn({
+      event: 'auth_failed',
+      method: 'bearer',
+      reason: 'invalid_or_expired_key',
+    });
     throw new UnauthorizedException('Invalid API key');
   }
 
@@ -179,6 +184,12 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
       .digest('base64');
 
     if (!safeCompare(expectedSignature, signature)) {
+      this.logger.warn({
+        event: 'auth_failed',
+        method: 'hmac',
+        reason: 'signature_mismatch',
+        keyId,
+      });
       throw new UnauthorizedException('Invalid HMAC signature');
     }
 

--- a/src/common/correlation.middleware.spec.ts
+++ b/src/common/correlation.middleware.spec.ts
@@ -1,0 +1,67 @@
+import { CorrelationMiddleware } from './correlation.middleware';
+import { correlationStorage } from './correlation.storage';
+
+const makeReq = (headers: Record<string, string> = {}) =>
+  ({ headers }) as unknown as import('express').Request;
+
+const makeRes = () => {
+  const headers: Record<string, string> = {};
+  return {
+    setHeader: (k: string, v: string) => {
+      headers[k] = v;
+    },
+    _headers: headers,
+  } as unknown as import('express').Response & {
+    _headers: Record<string, string>;
+  };
+};
+
+describe('CorrelationMiddleware', () => {
+  let middleware: CorrelationMiddleware;
+
+  beforeEach(() => {
+    middleware = new CorrelationMiddleware();
+  });
+
+  it('generates a UUID correlation ID when no header present', (done) => {
+    const req = makeReq();
+    const res = makeRes();
+
+    middleware.use(req, res, () => {
+      const store = correlationStorage.getStore();
+      expect(store?.correlationId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(res._headers['x-correlation-id']).toBe(store?.correlationId);
+      done();
+    });
+  });
+
+  it('propagates existing correlation ID from header', (done) => {
+    const existing = 'test-correlation-id-123';
+    const req = makeReq({ 'x-correlation-id': existing });
+    const res = makeRes();
+
+    middleware.use(req, res, () => {
+      const store = correlationStorage.getStore();
+      expect(store?.correlationId).toBe(existing);
+      expect(res._headers['x-correlation-id']).toBe(existing);
+      done();
+    });
+  });
+
+  it('ignores an oversized correlation ID and generates a new UUID', (done) => {
+    const oversized = 'a'.repeat(129);
+    const req = makeReq({ 'x-correlation-id': oversized });
+    const res = makeRes();
+
+    middleware.use(req, res, () => {
+      const store = correlationStorage.getStore();
+      expect(store?.correlationId).not.toBe(oversized);
+      expect(store?.correlationId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      done();
+    });
+  });
+});

--- a/src/common/correlation.middleware.ts
+++ b/src/common/correlation.middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'node:crypto';
+import { correlationStorage } from './correlation.storage';
+
+const MAX_CORRELATION_ID_LENGTH = 128;
+
+@Injectable()
+export class CorrelationMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    // Accept caller-supplied ID only if within a reasonable length bound to
+    // prevent oversized values from inflating log payloads. Generate a UUID
+    // otherwise. nodeId and endpoint are stamped later by HttpMetricsInterceptor
+    // after the request is routed and authenticated.
+    const incoming = req.headers['x-correlation-id'] as string | undefined;
+    const correlationId =
+      incoming && incoming.length <= MAX_CORRELATION_ID_LENGTH
+        ? incoming
+        : randomUUID();
+
+    res.setHeader('x-correlation-id', correlationId);
+
+    correlationStorage.run({ correlationId }, next);
+  }
+}

--- a/src/common/correlation.storage.ts
+++ b/src/common/correlation.storage.ts
@@ -1,0 +1,9 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export interface CorrelationStore {
+  correlationId: string;
+  nodeId?: string;
+  endpoint?: string;
+}
+
+export const correlationStorage = new AsyncLocalStorage<CorrelationStore>();

--- a/src/common/structured-logger.service.spec.ts
+++ b/src/common/structured-logger.service.spec.ts
@@ -1,0 +1,93 @@
+import { StructuredLoggerService } from './structured-logger.service';
+import { correlationStorage } from './correlation.storage';
+
+describe('StructuredLoggerService', () => {
+  let logger: StructuredLoggerService;
+
+  beforeEach(() => {
+    logger = new StructuredLoggerService('TestContext');
+  });
+
+  describe('dev mode (default)', () => {
+    it('logs without throwing', () => {
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      expect(() => logger.log('hello world')).not.toThrow();
+      spy.mockRestore();
+    });
+
+    it('logs warn and error without throwing', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      expect(() => logger.warn('a warning')).not.toThrow();
+      expect(() => logger.error('an error', 'stack trace')).not.toThrow();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('production mode (NODE_ENV=production)', () => {
+    let stdoutSpy: jest.SpyInstance;
+    const origEnv = process.env.NODE_ENV;
+
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+      stdoutSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation((_chunk: unknown) => true);
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = origEnv;
+      stdoutSpy.mockRestore();
+    });
+
+    const captureJson = (): Record<string, unknown> => {
+      const raw = (stdoutSpy.mock.calls as [string][]).map(([c]) => c).join('');
+      return JSON.parse(raw.trim()) as Record<string, unknown>;
+    };
+
+    it('emits structured JSON with required fields', () => {
+      logger.log('hello');
+      const parsed = captureJson();
+      expect(parsed.level).toBe('log');
+      expect(parsed.service).toBe('prompt-service');
+      expect(parsed.message).toBe('hello');
+      expect(typeof parsed.timestamp).toBe('string');
+    });
+
+    it('includes correlationId from ALS store', () => {
+      correlationStorage.run({ correlationId: 'corr-xyz' }, () => {
+        logger.log('hello');
+        expect(captureJson().correlationId).toBe('corr-xyz');
+      });
+    });
+
+    it('includes nodeId and endpoint from ALS store', () => {
+      correlationStorage.run(
+        { correlationId: 'c1', nodeId: 'node-1', endpoint: '/prompts/rag' },
+        () => {
+          logger.log('event');
+          const parsed = captureJson();
+          expect(parsed.nodeId).toBe('node-1');
+          expect(parsed.endpoint).toBe('/prompts/rag');
+        },
+      );
+    });
+
+    it('omits correlationId when ALS store is empty', () => {
+      logger.log('no context');
+      expect(captureJson()).not.toHaveProperty('correlationId');
+    });
+
+    it('includes context stripped of brackets', () => {
+      logger.log('action', 'MyService');
+      expect(captureJson().context).toBe('MyService');
+    });
+  });
+
+  it('handles missing ALS store gracefully', () => {
+    expect(correlationStorage.getStore()).toBeUndefined();
+  });
+});

--- a/src/common/structured-logger.service.ts
+++ b/src/common/structured-logger.service.ts
@@ -1,0 +1,55 @@
+import { ConsoleLogger, Injectable, LogLevel } from '@nestjs/common';
+import { correlationStorage } from './correlation.storage';
+
+@Injectable()
+export class StructuredLoggerService extends ConsoleLogger {
+  protected formatMessage(
+    logLevel: LogLevel,
+    message: unknown,
+    pidMessage: string,
+    formattedLogLevel: string,
+    contextMessage: string,
+    timestampDiff: string,
+  ): string {
+    if (process.env.NODE_ENV === 'production') {
+      return (
+        JSON.stringify(this.buildEntry(logLevel, message, contextMessage)) +
+        '\n'
+      );
+    }
+    return super.formatMessage(
+      logLevel,
+      message,
+      pidMessage,
+      formattedLogLevel,
+      contextMessage,
+      timestampDiff,
+    );
+  }
+
+  private buildEntry(
+    level: LogLevel,
+    message: unknown,
+    contextMessage: string,
+  ): Record<string, unknown> {
+    const store = correlationStorage.getStore();
+    const entry: Record<string, unknown> = {
+      timestamp: new Date().toISOString(),
+      level,
+      service: 'prompt-service',
+      message,
+    };
+
+    const ctx = contextMessage
+      .replace(/\x1B\[[0-9;]*m/g, '') // strip ANSI color codes added by NestJS
+      .replace(/[\[\]]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (ctx) entry.context = ctx;
+    if (store?.correlationId) entry.correlationId = store.correlationId;
+    if (store?.nodeId) entry.nodeId = store.nodeId;
+    if (store?.endpoint) entry.endpoint = store.endpoint;
+
+    return entry;
+  }
+}

--- a/src/experiments/experiments.service.ts
+++ b/src/experiments/experiments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../common/prisma.service';
 
@@ -22,6 +22,8 @@ interface VariantWithVersion {
 
 @Injectable()
 export class ExperimentsService {
+  private readonly logger = new Logger(ExperimentsService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   async resolveExperiment(
@@ -50,6 +52,14 @@ export class ExperimentsService {
       experiment.id,
       experiment.variants,
     );
+
+    this.logger.log({
+      event: 'experiment_variant_assigned',
+      templateName,
+      experimentId: experiment.id,
+      variantName: variant.name,
+      apiKeyPrefix: apiKey.slice(0, 8) + '...',
+    });
 
     return {
       templateText: variant.versionEntry.templateText,

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,16 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { StructuredLoggerService } from './common/structured-logger.service';
 
 async function bootstrap() {
+  const logger = new StructuredLoggerService('Bootstrap');
+  // Passing logger here tells NestJS to route all Logger instances (including
+  // `new Logger(ClassName)` used in services) through StructuredLoggerService,
+  // so every log line picks up correlation IDs from the ALS store.
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     rawBody: true,
+    logger,
   });
 
   // Bump body-parser limit. Default is 100KB; the civics-extraction
@@ -37,8 +43,8 @@ async function bootstrap() {
   const port = configService.get<number>('PORT', 3200);
 
   await app.listen(port);
-  console.log(`Prompt Service running on port ${port}`);
-  console.log(`Swagger docs at http://localhost:${port}/api`);
+  logger.log(`Prompt Service running on port ${port}`);
+  logger.log(`Swagger docs at http://localhost:${port}/api`);
 }
 
 bootstrap();

--- a/src/metrics/http-metrics.interceptor.spec.ts
+++ b/src/metrics/http-metrics.interceptor.spec.ts
@@ -1,0 +1,196 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { of, throwError } from 'rxjs';
+import { HttpMetricsInterceptor } from './http-metrics.interceptor';
+import { correlationStorage } from '../common/correlation.storage';
+import type { Counter, Histogram } from 'prom-client';
+
+const makeCounter = () => ({ inc: jest.fn() }) as unknown as Counter<string>;
+const makeHistogram = () =>
+  ({ observe: jest.fn() }) as unknown as Histogram<string>;
+
+function makeContext(
+  routePath: string,
+  method: string,
+  statusCode: number,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        route: { path: routePath },
+        url: routePath,
+        method,
+      }),
+      getResponse: () => ({ statusCode }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+function makeHandler(value: unknown): CallHandler {
+  return { handle: () => of(value) };
+}
+
+function makeErrorHandler(err: unknown): CallHandler {
+  return { handle: () => throwError(() => err) };
+}
+
+describe('HttpMetricsInterceptor', () => {
+  let counter: Counter<string>;
+  let histogram: Histogram<string>;
+  let interceptor: HttpMetricsInterceptor;
+
+  beforeEach(() => {
+    counter = makeCounter();
+    histogram = makeHistogram();
+    interceptor = new HttpMetricsInterceptor(counter, histogram);
+  });
+
+  it('increments request counter with correct labels on success', (done) => {
+    const ctx = makeContext('/prompts/:name/hash', 'GET', 200);
+
+    interceptor.intercept(ctx, makeHandler({})).subscribe({
+      complete: () => {
+        expect(counter.inc).toHaveBeenCalledWith({
+          endpoint: '/prompts/:name/hash',
+          method: 'GET',
+          status: '200',
+        });
+        done();
+      },
+    });
+  });
+
+  it('observes histogram on success', (done) => {
+    const ctx = makeContext('/prompts/structural-analysis', 'POST', 200);
+
+    interceptor.intercept(ctx, makeHandler({})).subscribe({
+      complete: () => {
+        expect(histogram.observe).toHaveBeenCalledWith(
+          { endpoint: '/prompts/structural-analysis', method: 'POST' },
+          expect.any(Number),
+        );
+        done();
+      },
+    });
+  });
+
+  it('records 401 status on auth error', (done) => {
+    const ctx = makeContext('/prompts/rag', 'POST', 200);
+    const err = { status: 401, message: 'Unauthorized' };
+
+    interceptor.intercept(ctx, makeErrorHandler(err)).subscribe({
+      error: () => {
+        expect(counter.inc).toHaveBeenCalledWith(
+          expect.objectContaining({ status: '401' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('falls back to 500 for errors without status', (done) => {
+    const ctx = makeContext('/prompts/rag', 'POST', 200);
+
+    interceptor.intercept(ctx, makeErrorHandler(new Error('boom'))).subscribe({
+      error: () => {
+        expect(counter.inc).toHaveBeenCalledWith(
+          expect.objectContaining({ status: '500' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('returns Express route template directly without modification', (done) => {
+    const ctx = makeContext('/admin/nodes/:id', 'GET', 200);
+
+    interceptor.intercept(ctx, makeHandler({})).subscribe({
+      complete: () => {
+        expect(counter.inc).toHaveBeenCalledWith(
+          expect.objectContaining({ endpoint: '/admin/nodes/:id' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('normalizes UUID in raw URL when route template is absent', (done) => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          route: undefined,
+          url: `/admin/nodes/${uuid}`,
+          method: 'GET',
+        }),
+        getResponse: () => ({ statusCode: 200 }),
+      }),
+    } as unknown as ExecutionContext;
+
+    interceptor.intercept(ctx, makeHandler({})).subscribe({
+      complete: () => {
+        expect(counter.inc).toHaveBeenCalledWith(
+          expect.objectContaining({ endpoint: '/admin/nodes/:id' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('normalizes numeric segments in raw URL when route template is absent', (done) => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          route: undefined,
+          url: '/admin/nodes/42',
+          method: 'GET',
+        }),
+        getResponse: () => ({ statusCode: 200 }),
+      }),
+    } as unknown as ExecutionContext;
+
+    interceptor.intercept(ctx, makeHandler({})).subscribe({
+      complete: () => {
+        expect(counter.inc).toHaveBeenCalledWith(
+          expect.objectContaining({ endpoint: '/admin/nodes/:id' }),
+        );
+        done();
+      },
+    });
+  });
+
+  it('stamps endpoint into the ALS correlation store', (done) => {
+    const ctx = makeContext('/prompts/rag', 'POST', 200);
+
+    correlationStorage.run({ correlationId: 'test-cid' }, () => {
+      interceptor.intercept(ctx, makeHandler({})).subscribe({
+        complete: () => {
+          expect(correlationStorage.getStore()?.endpoint).toBe('/prompts/rag');
+          done();
+        },
+      });
+    });
+  });
+
+  it('stamps nodeId into the ALS store when present on the request', (done) => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          route: { path: '/prompts/rag' },
+          url: '/prompts/rag',
+          method: 'POST',
+          nodeId: 'node-abc',
+        }),
+        getResponse: () => ({ statusCode: 200 }),
+      }),
+    } as unknown as ExecutionContext;
+
+    correlationStorage.run({ correlationId: 'test-cid' }, () => {
+      interceptor.intercept(ctx, makeHandler({})).subscribe({
+        complete: () => {
+          expect(correlationStorage.getStore()?.nodeId).toBe('node-abc');
+          done();
+        },
+      });
+    });
+  });
+});

--- a/src/metrics/http-metrics.interceptor.ts
+++ b/src/metrics/http-metrics.interceptor.ts
@@ -1,0 +1,87 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Counter, Histogram } from 'prom-client';
+import { Observable } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { throwError } from 'rxjs';
+import { correlationStorage } from '../common/correlation.storage';
+
+export const REQUEST_COUNT_METRIC = 'prompt_service_requests_total';
+export const REQUEST_DURATION_METRIC =
+  'prompt_service_request_duration_seconds';
+
+@Injectable()
+export class HttpMetricsInterceptor implements NestInterceptor {
+  constructor(
+    @InjectMetric(REQUEST_COUNT_METRIC)
+    private readonly requestCounter: Counter<string>,
+    @InjectMetric(REQUEST_DURATION_METRIC)
+    private readonly requestDuration: Histogram<string>,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const req = context.switchToHttp().getRequest();
+    const endpoint = this.normalizeRoute(req);
+    const method = req.method as string;
+    const start = Date.now();
+
+    // Stamp request metadata into the ALS store so every log line in this
+    // request carries the same endpoint and nodeId without explicit passing.
+    // nodeId is set by ApiKeyGuard after auth — it may be absent on
+    // unauthenticated routes (health, metrics).
+    const store = correlationStorage.getStore();
+    if (store) {
+      store.endpoint = endpoint;
+      if (req.nodeId) store.nodeId = req.nodeId as string;
+    }
+
+    return next.handle().pipe(
+      tap(() => {
+        const status = String(context.switchToHttp().getResponse().statusCode);
+        this.requestCounter.inc({ endpoint, method, status });
+        this.requestDuration.observe(
+          { endpoint, method },
+          (Date.now() - start) / 1000,
+        );
+      }),
+      catchError((err: unknown) => {
+        const status = this.errorStatus(err);
+        this.requestCounter.inc({ endpoint, method, status });
+        this.requestDuration.observe(
+          { endpoint, method },
+          (Date.now() - start) / 1000,
+        );
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  private normalizeRoute(req: {
+    route?: { path: string };
+    url: string;
+  }): string {
+    // Express route templates already use :param notation — return them directly
+    // to avoid double-processing and keep cardinality bounded.
+    // Fallback to raw URL normalization only when route template is unavailable
+    // (e.g., 404s, middleware-only requests).
+    if (req.route?.path) return req.route.path;
+    return req.url
+      .replace(
+        /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+        '/:id',
+      )
+      .replace(/\/\d+(?=\/|$)/g, '/:id');
+  }
+
+  private errorStatus(err: unknown): string {
+    if (err && typeof err === 'object' && 'status' in err) {
+      return String((err as { status: number }).status);
+    }
+    return '500';
+  }
+}

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,0 +1,40 @@
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import {
+  PrometheusModule,
+  makeCounterProvider,
+  makeHistogramProvider,
+} from '@willsoto/nestjs-prometheus';
+import {
+  HttpMetricsInterceptor,
+  REQUEST_COUNT_METRIC,
+  REQUEST_DURATION_METRIC,
+} from './http-metrics.interceptor';
+
+@Module({
+  imports: [
+    PrometheusModule.register({
+      path: '/metrics',
+      defaultMetrics: { enabled: true },
+    }),
+  ],
+  providers: [
+    makeCounterProvider({
+      name: REQUEST_COUNT_METRIC,
+      help: 'Total HTTP requests processed by prompt-service',
+      labelNames: ['endpoint', 'method', 'status'],
+    }),
+    makeHistogramProvider({
+      name: REQUEST_DURATION_METRIC,
+      help: 'HTTP request duration in seconds',
+      labelNames: ['endpoint', 'method'],
+      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+    }),
+    HttpMetricsInterceptor,
+    {
+      provide: APP_INTERCEPTOR,
+      useExisting: HttpMetricsInterceptor,
+    },
+  ],
+})
+export class MetricsModule {}


### PR DESCRIPTION
## Summary

- Adds `AsyncLocalStorage`-based correlation ID propagation so every log line for a request carries the same `X-Correlation-Id` that was echoed in the response header — traceable end-to-end in any log aggregator
- `StructuredLoggerService` extends NestJS `ConsoleLogger`: JSON output in production (with `correlationId`, `nodeId`, `endpoint`, `level`, `service`, `timestamp`), pretty-print in dev — no new logging dependency
- `HttpMetricsInterceptor` records `prompt_service_requests_total` (counter) and `prompt_service_request_duration_seconds` (histogram) via `@willsoto/nestjs-prometheus`; endpoint labels use Express route templates directly to keep cardinality bounded
- Structured audit events added to `NodeRegistryService`, `ApiKeyGuard`, and `ExperimentsService` (object args with `event` field)
- Postman collection updated: port corrected (3200→3210), `bill-extraction` and `bill-votes-extraction` endpoints added, `GET /metrics` added, health dashboard assertion fixed (`total`→`totalNodes`)

## Review findings addressed (post-op-review)

- **B1** `nodeId` now stamped into ALS store by interceptor after auth, so authenticated log lines carry node identity
- **B2** Production JSON path fully tested via `process.stdout.write` spy; `IS_PRODUCTION` inlined so `NODE_ENV` changes in tests take effect without module reload
- **S1** `X-Correlation-Id` header capped at 128 chars; oversized values generate a fresh UUID
- **S2** `normalizeRoute` returns Express route templates as-is; `\/\d+` fixed with `(?=\/|$)` lookahead
- **S4** `structured-logger.service.ts` removed from coverage exclusion (now properly tested — 90% branch coverage overall)
- **N2** Context strips ANSI color codes (NestJS wraps context in escape sequences) before bracket removal
- **N4** Dead `exports: [HttpMetricsInterceptor]` removed from `MetricsModule`

## Test plan

- [ ] `pnpm test` — 216 tests, all pass
- [ ] `pnpm test:cov` — 97% statements, 90% branches (threshold: 85%)
- [ ] `pnpm lint` — clean
- [ ] Docker: `docker compose build --no-cache opuspopuli-prompts && docker compose up -d --force-recreate opuspopuli-prompts`
- [ ] `curl http://localhost:3210/health` → `{ status: "ok", auditLogFailures: 0, activeTemplates: 21 }` with `x-correlation-id` header
- [ ] `curl http://localhost:3210/metrics` → `prompt_service_requests_total` and `prompt_service_request_duration_seconds` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)