### PR TITLE
feat(auth): per-node rate limiting and cert expiry alerting (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nestjs/config": "^3.3.0",
     "@nestjs/core": "^10.4.0",
     "@nestjs/platform-express": "^10.4.0",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^7.4.0",
     "@nestjs/throttler": "^6.3.0",
     "@prisma/client": "^6.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^10.4.0
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/schedule':
+        specifier: ^6.1.3
+        version: 6.1.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
       '@nestjs/swagger':
         specifier: ^7.4.0
         version: 7.4.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
@@ -550,6 +553,12 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
 
+  '@nestjs/schedule@6.1.3':
+    resolution: {integrity: sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@10.2.3':
     resolution: {integrity: sha512-4e8gxaCk7DhBxVUly2PjYL4xC2ifDFexCqq1/u4TtivLGXotVk0wHdYuPYe1tHTHuR1lsOkRbfOCpkdTnigLVg==}
     peerDependencies:
@@ -742,6 +751,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/luxon@3.7.1':
+    resolution: {integrity: sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -1341,6 +1353,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.4.0:
+    resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
+    engines: {node: '>=18.x'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2283,6 +2299,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
@@ -3915,6 +3935,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.1.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.4.0
+
   '@nestjs/schematics@10.2.3(chokidar@3.6.0)(typescript@5.7.2)':
     dependencies:
       '@angular-devkit/core': 17.3.11(chokidar@3.6.0)
@@ -4142,6 +4168,8 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/luxon@3.7.1': {}
 
   '@types/mime@1.3.5': {}
 
@@ -4815,6 +4843,11 @@ snapshots:
       - ts-node
 
   create-require@1.1.1: {}
+
+  cron@4.4.0:
+    dependencies:
+      '@types/luxon': 3.7.1
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6018,6 +6051,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.8:
     dependencies:

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
+import { makeGaugeProvider } from '@willsoto/nestjs-prometheus';
 import { AdminController } from './admin.controller';
 import { ExperimentsAdminController } from './experiments-admin.controller';
 import { NodeRegistryController } from './node-registry.controller';
 import { AdminService } from './admin.service';
 import { NodeRegistryService } from './node-registry.service';
+import {
+  CertExpirySchedulerService,
+  CERT_EXPIRY_CRITICAL_METRIC,
+  CERT_EXPIRY_SOON_METRIC,
+} from './cert-expiry-scheduler.service';
 
 @Module({
   controllers: [
@@ -11,6 +17,18 @@ import { NodeRegistryService } from './node-registry.service';
     ExperimentsAdminController,
     NodeRegistryController,
   ],
-  providers: [AdminService, NodeRegistryService],
+  providers: [
+    AdminService,
+    NodeRegistryService,
+    CertExpirySchedulerService,
+    makeGaugeProvider({
+      name: CERT_EXPIRY_SOON_METRIC,
+      help: 'Number of certified nodes whose certification expires within 30 days',
+    }),
+    makeGaugeProvider({
+      name: CERT_EXPIRY_CRITICAL_METRIC,
+      help: 'Number of certified nodes whose certification expires within 7 days',
+    }),
+  ],
 })
 export class AdminModule {}

--- a/src/admin/cert-expiry-scheduler.service.spec.ts
+++ b/src/admin/cert-expiry-scheduler.service.spec.ts
@@ -1,0 +1,135 @@
+import { Test } from '@nestjs/testing';
+import { getToken } from '@willsoto/nestjs-prometheus';
+import { Gauge } from 'prom-client';
+import { PrismaService } from '../common/prisma.service';
+import {
+  CertExpirySchedulerService,
+  CERT_EXPIRY_CRITICAL_METRIC,
+  CERT_EXPIRY_SOON_METRIC,
+} from './cert-expiry-scheduler.service';
+
+function makePrisma(nodes: object[] = []) {
+  return {
+    node: {
+      findMany: jest.fn().mockResolvedValue(nodes),
+    },
+  };
+}
+
+function makeGauge(): jest.Mocked<Gauge> {
+  return { set: jest.fn() } as unknown as jest.Mocked<Gauge>;
+}
+
+async function buildService(
+  prisma: object,
+  soonGauge: Gauge,
+  criticalGauge: Gauge,
+) {
+  const module = await Test.createTestingModule({
+    providers: [
+      CertExpirySchedulerService,
+      { provide: PrismaService, useValue: prisma },
+      { provide: getToken(CERT_EXPIRY_SOON_METRIC), useValue: soonGauge },
+      {
+        provide: getToken(CERT_EXPIRY_CRITICAL_METRIC),
+        useValue: criticalGauge,
+      },
+    ],
+  }).compile();
+
+  return module.get(CertExpirySchedulerService);
+}
+
+describe('CertExpirySchedulerService', () => {
+  it('sets gauges to 0 and logs nothing when no certs are expiring', async () => {
+    const prisma = makePrisma([]);
+    const soonGauge = makeGauge();
+    const criticalGauge = makeGauge();
+    const svc = await buildService(prisma, soonGauge, criticalGauge);
+
+    await svc.checkCertExpiry();
+
+    expect(soonGauge.set).toHaveBeenCalledWith(0);
+    expect(criticalGauge.set).toHaveBeenCalledWith(0);
+  });
+
+  it('sets expiringSoon gauge to node count and logs a warning per node', async () => {
+    const expiresAt = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000); // 20 days out
+    const nodes = [
+      {
+        id: 'n1',
+        name: 'ca-node',
+        region: 'ca',
+        certificationExpiresAt: expiresAt,
+      },
+      {
+        id: 'n2',
+        name: 'tx-node',
+        region: 'tx',
+        certificationExpiresAt: expiresAt,
+      },
+    ];
+    const prisma = makePrisma(nodes);
+    const soonGauge = makeGauge();
+    const criticalGauge = makeGauge();
+    const svc = await buildService(prisma, soonGauge, criticalGauge);
+
+    await svc.checkCertExpiry();
+
+    expect(soonGauge.set).toHaveBeenCalledWith(2);
+    expect(criticalGauge.set).toHaveBeenCalledWith(0);
+  });
+
+  it('counts critical nodes (expiring ≤7 days) separately', async () => {
+    const criticalAt = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000); // 3 days
+    const soonAt = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000); // 20 days
+    const nodes = [
+      {
+        id: 'n1',
+        name: 'ca-node',
+        region: 'ca',
+        certificationExpiresAt: criticalAt,
+      },
+      {
+        id: 'n2',
+        name: 'tx-node',
+        region: 'tx',
+        certificationExpiresAt: soonAt,
+      },
+    ];
+    const prisma = makePrisma(nodes);
+    const soonGauge = makeGauge();
+    const criticalGauge = makeGauge();
+    const svc = await buildService(prisma, soonGauge, criticalGauge);
+
+    await svc.checkCertExpiry();
+
+    expect(soonGauge.set).toHaveBeenCalledWith(2);
+    expect(criticalGauge.set).toHaveBeenCalledWith(1);
+  });
+
+  it('queries only certified nodes within the 30-day window', async () => {
+    const prisma = makePrisma([]);
+    const svc = await buildService(prisma, makeGauge(), makeGauge());
+
+    await svc.checkCertExpiry();
+
+    const call = (prisma.node.findMany as jest.Mock).mock.calls[0][0];
+    expect(call.where.status).toBe('certified');
+    expect(call.where.certificationExpiresAt).toMatchObject({
+      lte: expect.any(Date),
+      gt: expect.any(Date),
+    });
+  });
+
+  it('onModuleInit swallows DB errors so a transient failure cannot crash the service', async () => {
+    const prisma = {
+      node: {
+        findMany: jest.fn().mockRejectedValue(new Error('DB unreachable')),
+      },
+    };
+    const svc = await buildService(prisma, makeGauge(), makeGauge());
+
+    await expect(svc.onModuleInit()).resolves.not.toThrow();
+  });
+});

--- a/src/admin/cert-expiry-scheduler.service.ts
+++ b/src/admin/cert-expiry-scheduler.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Gauge } from 'prom-client';
+import { PrismaService } from '../common/prisma.service';
+
+export const CERT_EXPIRY_SOON_METRIC = 'node_certs_expiring_soon';
+export const CERT_EXPIRY_CRITICAL_METRIC = 'node_certs_expiring_critical';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class CertExpirySchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(CertExpirySchedulerService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    @InjectMetric(CERT_EXPIRY_SOON_METRIC)
+    private readonly expiringSoonGauge: Gauge,
+    @InjectMetric(CERT_EXPIRY_CRITICAL_METRIC)
+    private readonly expiringCriticalGauge: Gauge,
+  ) {}
+
+  async onModuleInit() {
+    // Populate gauges at startup so Prometheus has initial values before the
+    // first hourly cron tick. Errors are swallowed — a transient DB hiccup at
+    // boot must not crash the service; the cron will retry on the next tick.
+    try {
+      await this.checkCertExpiry();
+    } catch {
+      this.logger.warn(
+        'Could not run cert expiry check on startup, will retry on next cron tick',
+      );
+    }
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async checkCertExpiry() {
+    const now = new Date();
+    const in30Days = new Date(now.getTime() + THIRTY_DAYS_MS);
+    const in7Days = new Date(now.getTime() + SEVEN_DAYS_MS);
+
+    const expiringNodes = await this.prisma.node.findMany({
+      where: {
+        status: 'certified',
+        certificationExpiresAt: { lte: in30Days, gt: now },
+      },
+      select: {
+        id: true,
+        name: true,
+        region: true,
+        certificationExpiresAt: true,
+      },
+      orderBy: { certificationExpiresAt: 'asc' },
+    });
+
+    const criticalCount = expiringNodes.filter(
+      (n) => n.certificationExpiresAt! <= in7Days,
+    ).length;
+
+    this.expiringSoonGauge.set(expiringNodes.length);
+    this.expiringCriticalGauge.set(criticalCount);
+
+    for (const node of expiringNodes) {
+      const msRemaining =
+        node.certificationExpiresAt!.getTime() - now.getTime();
+      const daysRemaining = Math.ceil(msRemaining / (24 * 60 * 60 * 1000));
+
+      this.logger.warn({
+        event: 'cert_expiry_warning',
+        nodeId: node.id,
+        name: node.name,
+        region: node.region,
+        daysRemaining,
+      });
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from './common/prisma.module';
 import { CorrelationMiddleware } from './common/correlation.middleware';
@@ -12,6 +13,7 @@ import { MetricsModule } from './metrics/metrics.module';
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }]),
     PrismaModule,
     HealthModule,

--- a/src/auth/node-throttler.guard.spec.ts
+++ b/src/auth/node-throttler.guard.spec.ts
@@ -1,0 +1,83 @@
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { Reflector } from '@nestjs/core';
+import { createHash } from 'node:crypto';
+import { NodeThrottlerGuard } from './node-throttler.guard';
+
+function makeGuard() {
+  const storage = {
+    increment: jest.fn().mockResolvedValue({
+      totalHits: 1,
+      timeToExpire: 0,
+      isBlocked: false,
+      timeToBlockExpire: 0,
+    }),
+  } as unknown as ThrottlerStorage;
+  const reflector = {
+    getAllAndOverride: jest.fn().mockReturnValue(undefined),
+  } as unknown as Reflector;
+  const options = [{ name: 'default', ttl: 60_000, limit: 30 }];
+  return new NodeThrottlerGuard(options as never, storage, reflector);
+}
+
+describe('NodeThrottlerGuard.getTracker', () => {
+  let guard: NodeThrottlerGuard;
+
+  beforeEach(() => {
+    guard = makeGuard();
+  });
+
+  it('returns node:<nodeId> when nodeId is present', async () => {
+    const req = { nodeId: 'uuid-abc', apiKey: 'key-xyz', ip: '1.2.3.4' };
+    // Access protected method via type cast for unit testing
+    const tracker = await (
+      guard as unknown as { getTracker(r: unknown): Promise<string> }
+    ).getTracker(req);
+    expect(tracker).toBe('node:uuid-abc');
+  });
+
+  it('returns key:<sha256> when only apiKey is present (env-var auth path)', async () => {
+    const req = { apiKey: 'abcdefgh-rest-of-key', ip: '1.2.3.4' };
+    const tracker = await (
+      guard as unknown as { getTracker(r: unknown): Promise<string> }
+    ).getTracker(req);
+    const expectedHash = createHash('sha256')
+      .update('abcdefgh-rest-of-key')
+      .digest('hex');
+    expect(tracker).toBe(`key:${expectedHash}`);
+  });
+
+  it('gives distinct buckets to keys that share the same 8-char prefix', async () => {
+    const getTracker = (req: unknown) =>
+      (
+        guard as unknown as { getTracker(r: unknown): Promise<string> }
+      ).getTracker(req);
+
+    const t1 = await getTracker({ apiKey: 'dev-key-1' });
+    const t2 = await getTracker({ apiKey: 'dev-key-2' });
+    expect(t1).not.toBe(t2);
+  });
+
+  it('returns ip:<addr> when neither nodeId nor apiKey is set', async () => {
+    const req = { ip: '10.0.0.1' };
+    const tracker = await (
+      guard as unknown as { getTracker(r: unknown): Promise<string> }
+    ).getTracker(req);
+    expect(tracker).toBe('ip:10.0.0.1');
+  });
+
+  it('returns ip:unknown when no identity info at all', async () => {
+    const req = {};
+    const tracker = await (
+      guard as unknown as { getTracker(r: unknown): Promise<string> }
+    ).getTracker(req);
+    expect(tracker).toBe('ip:unknown');
+  });
+
+  it('prefers nodeId over apiKey when both are present', async () => {
+    const req = { nodeId: 'node-1', apiKey: 'key-1', ip: '1.2.3.4' };
+    const tracker = await (
+      guard as unknown as { getTracker(r: unknown): Promise<string> }
+    ).getTracker(req);
+    expect(tracker).toBe('node:node-1');
+  });
+});

--- a/src/auth/node-throttler.guard.ts
+++ b/src/auth/node-throttler.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { createHash } from 'node:crypto';
+
+/**
+ * Extends the default IP-based throttler to key buckets on the authenticated
+ * node identity populated by ApiKeyGuard. Must be applied AFTER ApiKeyGuard
+ * so that req.nodeId / req.apiKey are already set.
+ *
+ * Tracker precedence: nodeId → SHA-256(apiKey) → IP (fallback for unauthenticated
+ * paths, which shouldn't reach this guard in practice).
+ */
+@Injectable()
+export class NodeThrottlerGuard extends ThrottlerGuard {
+  protected async getTracker(req: Record<string, unknown>): Promise<string> {
+    const nodeId = req.nodeId as string | undefined;
+    if (nodeId) return `node:${nodeId}`;
+
+    const apiKey = req.apiKey as string | undefined;
+    if (apiKey) {
+      // Hash the full key so every distinct key gets its own bucket regardless
+      // of shared prefixes (e.g. dev-key-1 and dev-key-2 both start with "dev-key-").
+      const hash = createHash('sha256').update(apiKey).digest('hex');
+      return `key:${hash}`;
+    }
+
+    // Fallback: use Express ip (set by platform)
+    const ip = (req.ip as string | undefined) ?? 'unknown';
+    return `ip:${ip}`;
+  }
+}

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { PromptsController } from './prompts.controller';
 import { PromptsService } from './prompts.service';
+import { NodeThrottlerGuard } from '../auth/node-throttler.guard';
 import { PrismaService } from '../common/prisma.service';
 import { VaultService } from '../common/vault.service';
 
@@ -11,8 +13,10 @@ describe('PromptsController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }])],
       controllers: [PromptsController],
       providers: [
+        NodeThrottlerGuard,
         {
           provide: PromptsService,
           useValue: {

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { ApiKeyGuard } from '../auth/api-key.guard';
+import { NodeThrottlerGuard } from '../auth/node-throttler.guard';
 import { PromptsService } from './prompts.service';
 import { StructuralAnalysisDto } from './dto/structural-analysis.dto';
 import { DocumentAnalysisDto } from './dto/document-analysis.dto';
@@ -42,12 +43,14 @@ function ApiPromptResponses() {
 
 @ApiTags('prompts')
 @Controller('prompts')
+// ApiKeyGuard must come before NodeThrottlerGuard so req.nodeId / req.apiKey
+// are populated before the per-node bucket key is resolved.
+@UseGuards(ApiKeyGuard, NodeThrottlerGuard)
+@ApiBearerAuth()
 export class PromptsController {
   constructor(private readonly promptsService: PromptsService) {}
 
   @Post('structural-analysis')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({ summary: 'Get structural analysis prompt' })
   @ApiPromptResponses()
@@ -63,8 +66,6 @@ export class PromptsController {
   }
 
   @Post('document-analysis')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({ summary: 'Get document analysis prompt' })
   @ApiPromptResponses()
@@ -80,8 +81,6 @@ export class PromptsController {
   }
 
   @Post('rag')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({ summary: 'Get RAG prompt' })
   @ApiPromptResponses()
@@ -93,8 +92,6 @@ export class PromptsController {
   }
 
   @Post('civics-extraction')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({
     summary:
@@ -113,8 +110,6 @@ export class PromptsController {
   }
 
   @Post('bill-extraction')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({
     summary:
@@ -133,8 +128,6 @@ export class PromptsController {
   }
 
   @Post('bill-votes-extraction')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @Throttle({ default: { ttl: 60_000, limit: 30 } })
   @ApiOperation({
     summary:
@@ -153,8 +146,6 @@ export class PromptsController {
   }
 
   @Post('verify')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
   @ApiOperation({ summary: 'Verify a prompt hash is authentic' })
   @ApiResponse({ status: 200, description: 'Verification result' })
   @ApiResponse({ status: 401, description: INVALID_API_KEY })
@@ -169,8 +160,10 @@ export class PromptsController {
    * truth for manifest cache invalidation.
    */
   @Get(':name/hash')
-  @UseGuards(ApiKeyGuard)
-  @ApiBearerAuth()
+  // 120/min vs 30/min on composition endpoints: this endpoint is a DB lookup
+  // only (no interpolation, no experiment bucketing, no request log write).
+  // The 4x headroom reflects the real cost differential and allows clients to
+  // poll for cache invalidation without crowding out composition quota.
   @Throttle({ default: { ttl: 60_000, limit: 120 } })
   @ApiOperation({ summary: 'Get the hash of a named prompt template' })
   @ApiResponse({

--- a/src/prompts/prompts.module.ts
+++ b/src/prompts/prompts.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { NodeThrottlerGuard } from '../auth/node-throttler.guard';
 import { PromptsController } from './prompts.controller';
 import { PromptsService } from './prompts.service';
 
 @Module({
   controllers: [PromptsController],
-  providers: [PromptsService],
+  providers: [PromptsService, NodeThrottlerGuard],
   exports: [PromptsService],
 })
 export class PromptsModule {}


### PR DESCRIPTION
## Summary

Closes #28 — federation-scale concerns: per-node quota isolation and proactive cert expiry alerting.

- **Per-node rate limiting** (`NodeThrottlerGuard`) — extends `ThrottlerGuard` keyed on `nodeId` (HMAC path) or `SHA-256(apiKey)` (env-var path). Each node gets its own 30 req/min quota; one misbehaving node can no longer exhaust the shared pool. Applied at class level on `PromptsController` after `ApiKeyGuard` so node identity is populated before the bucket key is resolved. Keys with a shared prefix (`dev-key-1`, `dev-key-2`) get distinct buckets via the hash.

- **Cert expiry alerting** (`CertExpirySchedulerService`) — hourly cron scans for certified nodes expiring within 30 days, emits a structured warning log per node, and updates two Prometheus gauges:
  - `node_certs_expiring_soon` — count expiring ≤30 days
  - `node_certs_expiring_critical` — count expiring ≤7 days (urgent)
  - Gauges populated at startup via `onModuleInit` (with try/catch so a transient DB error cannot crash the service)

- **Hash endpoint rate-limit differential** documented inline (120/min vs 30/min on composition endpoints — DB lookup only, no interpolation, no experiment bucketing, no audit log write).

- Added `@nestjs/schedule` (MIT).

## Test plan

- [x] 231 unit tests passing (`pnpm test`)
- [x] 101 integration tests passing (`pnpm test:integration:docker`)
- [x] Lint clean (`pnpm lint`)
- [x] Docker image builds and container healthy at `localhost:3210`

🤖 Generated with [Claude Code](https://claude.com/claude-code)