### PR TITLE
refactor(auth): drop plaintext node API key storage, atomic key rotation

### DIFF
--- a/prisma/migrations/20260524000000_make_node_api_key_nullable/migration.sql
+++ b/prisma/migrations/20260524000000_make_node_api_key_nullable/migration.sql
@@ -1,0 +1,19 @@
+-- Phase 1 of dropping the plaintext nodes.api_key column (issue #59).
+-- Service code stops reading and writing this column in the same PR.
+-- The column itself is dropped in a follow-up migration once this change
+-- has been deployed and verified (additive-only rule per CLAUDE.md).
+--
+-- Auth paths after this migration:
+--   - Bearer: lookup by api_key_hash (already in place)
+--   - HMAC:   lookup by id + Vault.getSecret(api_key_secret_id) (already in place)
+-- The plaintext value is returned in registration/rotation response bodies
+-- only; it never re-enters the DB.
+
+-- Drop unique constraint so future inserts can leave api_key NULL
+DROP INDEX IF EXISTS "nodes_api_key_key";
+
+-- Drop secondary lookup index — no code path queries by plaintext key
+DROP INDEX IF EXISTS "nodes_api_key_idx";
+
+-- Allow NULL so service code can stop writing the column
+ALTER TABLE "nodes" ALTER COLUMN "api_key" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,7 +101,11 @@ model Node {
   /// Reserved for future node-to-service signature verification (planned follow-on to HMAC auth).
   /// Accepted on register/update but not currently read by any service code. Do not remove.
   publicKey              String?   @map("public_key")
-  apiKey                 String    @unique @map("api_key")
+  /// Deprecated: plaintext key was migrated out in issue #59. Column retained
+  /// nullable to satisfy "additive only" rule; dropped in a follow-up migration
+  /// once this change is deployed and verified. Do not read or write this field
+  /// — Bearer auth uses apiKeyHash, HMAC auth uses apiKeySecretId via Vault.
+  apiKey                 String?   @map("api_key")
   apiKeyHash             String?   @map("api_key_hash")
   apiKeySecretId         String?   @map("api_key_secret_id")
   status                 String    @default("pending") // pending, certified, decertified, expired
@@ -115,7 +119,6 @@ model Node {
 
   @@index([region])
   @@index([status])
-  @@index([apiKey])
   @@index([apiKeyHash])
   @@map("nodes")
 }

--- a/src/admin/node-registry.service.spec.ts
+++ b/src/admin/node-registry.service.spec.ts
@@ -53,12 +53,11 @@ describe('NodeRegistryService', () => {
   });
 
   describe('registerNode', () => {
-    it('should create node with generated API key, hash, and audit log', async () => {
+    it('should create node with hash and audit log (no plaintext apiKey column write)', async () => {
       const dto = { name: 'node-ca-01', region: 'ca' };
       const created = {
         id: 'uuid-1',
         ...dto,
-        apiKey: 'generated-key',
         apiKeyHash: 'generated-hash',
         status: 'pending',
       };
@@ -69,17 +68,24 @@ describe('NodeRegistryService', () => {
 
       const result = await service.registerNode(dto, 'admin-te...');
 
-      expect(result).toEqual(created);
-      expect(prisma._tx.node.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+      // Response must include the plaintext apiKey (admin needs it once to
+      // hand off to the node operator) — issue #59 contract.
+      expect(result.apiKey).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.apiKeySecretId).toBe('vault-secret-uuid');
+
+      const createCall = prisma._tx.node.create.mock.calls[0][0];
+      expect(createCall.data).toEqual(
+        expect.objectContaining({
           name: 'node-ca-01',
           region: 'ca',
           publicKey: null,
           status: 'pending',
-          apiKey: expect.any(String),
           apiKeyHash: expect.any(String),
         }),
-      });
+      );
+      // Critical: plaintext apiKey must NOT be written to the row.
+      expect(createCall.data).not.toHaveProperty('apiKey');
+
       expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
         data: {
           nodeId: 'uuid-1',
@@ -94,7 +100,6 @@ describe('NodeRegistryService', () => {
       prisma._tx.node.create.mockResolvedValue({
         id: 'uuid-1',
         name: 'node-ca-01',
-        apiKey: 'gen-key',
       });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
       prisma.node.update.mockResolvedValue({});
@@ -124,7 +129,7 @@ describe('NodeRegistryService', () => {
       });
     });
 
-    it('should handle Vault failure gracefully', async () => {
+    it('should still return plaintext apiKey when Vault write fails', async () => {
       const dto = { name: 'node-ca-01', region: 'ca' };
       prisma._tx.node.create.mockResolvedValue({
         id: 'uuid-1',
@@ -133,30 +138,33 @@ describe('NodeRegistryService', () => {
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
       vault.createSecret.mockRejectedValue(new Error('Vault unavailable'));
 
-      // Should not throw
+      // Should not throw — Vault failure is non-fatal for registration
       const result = await service.registerNode(dto, 'admin...');
-      expect(result).toBeDefined();
+
+      // Plaintext key must still come back so the operator isn't stranded.
+      // Bearer auth still works via apiKeyHash; HMAC will be unavailable until
+      // Vault recovers (apiKeySecretId remains null).
+      expect(result.apiKey).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.apiKeySecretId).toBeNull();
     });
   });
 
-  describe('generateApiKey', () => {
-    it('should generate a 64-character hex string', async () => {
+  describe('generated API key', () => {
+    it('returns a 64-character hex string in the response', async () => {
       const dto = { name: 'node-key-test', region: 'ca' };
       prisma._tx.node.create.mockResolvedValue({
         id: '1',
         ...dto,
-        apiKey: '',
         status: 'pending',
       });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
 
-      await service.registerNode(dto, 'admin...');
+      const result = await service.registerNode(dto, 'admin...');
 
-      const createCall = prisma._tx.node.create.mock.calls[0][0];
-      expect(createCall.data.apiKey).toMatch(/^[a-f0-9]{64}$/);
+      expect(result.apiKey).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('should generate a valid SHA-256 hash alongside the key', async () => {
+    it('writes a valid SHA-256 hash of the key to the DB', async () => {
       const dto = { name: 'node-hash-test', region: 'ca' };
       prisma._tx.node.create.mockResolvedValue({ id: '1' });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
@@ -167,16 +175,20 @@ describe('NodeRegistryService', () => {
       expect(createCall.data.apiKeyHash).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('should generate unique keys on each call', async () => {
+    it('generates unique keys on each call', async () => {
       prisma._tx.node.create.mockResolvedValue({ id: '1' });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
 
-      await service.registerNode({ name: 'a', region: 'ca' }, 'admin...');
-      await service.registerNode({ name: 'b', region: 'ca' }, 'admin...');
+      const r1 = await service.registerNode(
+        { name: 'a', region: 'ca' },
+        'admin...',
+      );
+      const r2 = await service.registerNode(
+        { name: 'b', region: 'ca' },
+        'admin...',
+      );
 
-      const key1 = prisma._tx.node.create.mock.calls[0][0].data.apiKey;
-      const key2 = prisma._tx.node.create.mock.calls[1][0].data.apiKey;
-      expect(key1).not.toBe(key2);
+      expect(r1.apiKey).not.toBe(r2.apiKey);
     });
   });
 
@@ -476,29 +488,31 @@ describe('NodeRegistryService', () => {
   });
 
   describe('rotateApiKey', () => {
-    it('should generate a new API key with hash and create audit log', async () => {
+    it('should flip hash + secretId in a single tx and create audit log (no plaintext column write)', async () => {
       prisma.node.findUnique.mockResolvedValue({
         id: '1',
-        apiKey: 'old-key',
+        name: 'test-node',
         apiKeySecretId: 'old-secret-id',
       });
       prisma._tx.node.update.mockResolvedValue({
         id: '1',
         name: 'test-node',
-        apiKey: 'new-key',
+        apiKeyHash: 'new-hash',
+        apiKeySecretId: 'vault-secret-uuid',
       });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
-      prisma.node.update.mockResolvedValue({});
 
       const result = await service.rotateApiKey('1', 'admin...');
 
-      expect(prisma._tx.node.update).toHaveBeenCalledWith({
-        where: { id: '1' },
-        data: {
-          apiKey: expect.any(String),
-          apiKeyHash: expect.any(String),
-        },
+      const updateCall = prisma._tx.node.update.mock.calls[0][0];
+      expect(updateCall.where).toEqual({ id: '1' });
+      expect(updateCall.data).toEqual({
+        apiKeyHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        apiKeySecretId: 'vault-secret-uuid',
       });
+      // Critical: plaintext apiKey must NOT be written to the row.
+      expect(updateCall.data).not.toHaveProperty('apiKey');
+
       expect(prisma._tx.nodeAuditLog.create).toHaveBeenCalledWith({
         data: {
           nodeId: '1',
@@ -506,30 +520,86 @@ describe('NodeRegistryService', () => {
           performedBy: 'admin...',
         },
       });
-      expect(result.apiKey).toBeDefined();
+
+      // Response includes the new plaintext key for the admin caller.
+      expect(result.apiKey).toMatch(/^[a-f0-9]{64}$/);
     });
 
-    it('should store new key in Vault and delete old secret', async () => {
+    it('should write Vault secret BEFORE running the DB transaction (atomicity)', async () => {
       prisma.node.findUnique.mockResolvedValue({
         id: '1',
-        apiKey: 'old-key',
+        name: 'test-node',
         apiKeySecretId: 'old-secret-id',
       });
-      prisma._tx.node.update.mockResolvedValue({
-        id: '1',
-        name: 'test-node',
-      });
+      prisma._tx.node.update.mockResolvedValue({ id: '1', name: 'test-node' });
       prisma._tx.nodeAuditLog.create.mockResolvedValue({});
-      prisma.node.update.mockResolvedValue({});
+
+      const callOrder: string[] = [];
+      vault.createSecret.mockImplementation(async () => {
+        callOrder.push('vault.createSecret');
+        return 'vault-secret-uuid';
+      });
+      prisma.$transaction.mockImplementation(
+        async (cb: (tx: typeof prisma._tx) => unknown) => {
+          callOrder.push('prisma.$transaction');
+          return cb(prisma._tx);
+        },
+      );
 
       await service.rotateApiKey('1', 'admin...');
 
-      expect(vault.createSecret).toHaveBeenCalledWith(
-        expect.any(String),
-        'node_key_1',
-        expect.stringContaining('rotated'),
-      );
+      expect(callOrder).toEqual(['vault.createSecret', 'prisma.$transaction']);
       expect(vault.deleteSecret).toHaveBeenCalledWith('old-secret-id');
+    });
+
+    it('should leave DB unchanged when Vault.createSecret fails (issue #59 atomicity)', async () => {
+      prisma.node.findUnique.mockResolvedValue({
+        id: '1',
+        name: 'test-node',
+        apiKeySecretId: 'old-secret-id',
+      });
+      vault.createSecret.mockRejectedValue(new Error('Vault unavailable'));
+
+      await expect(service.rotateApiKey('1', 'admin...')).rejects.toThrow(
+        'Vault unavailable',
+      );
+
+      // No DB writes happened — node keeps its previous hash + secretId
+      // and remains authenticatable via both Bearer and HMAC paths.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(prisma._tx.node.update).not.toHaveBeenCalled();
+      expect(prisma._tx.nodeAuditLog.create).not.toHaveBeenCalled();
+      expect(vault.deleteSecret).not.toHaveBeenCalled();
+    });
+
+    it('should not fail rotation when old Vault secret cleanup fails', async () => {
+      prisma.node.findUnique.mockResolvedValue({
+        id: '1',
+        name: 'test-node',
+        apiKeySecretId: 'old-secret-id',
+      });
+      prisma._tx.node.update.mockResolvedValue({ id: '1', name: 'test-node' });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+      vault.deleteSecret.mockRejectedValue(new Error('Vault delete failed'));
+
+      // Cleanup failure is best-effort — rotation still succeeds. Worst case
+      // is an orphaned Vault secret, which ops can reap separately.
+      const result = await service.rotateApiKey('1', 'admin...');
+      expect(result.apiKey).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('should skip old-secret cleanup when previous secretId is null', async () => {
+      prisma.node.findUnique.mockResolvedValue({
+        id: '1',
+        name: 'test-node',
+        apiKeySecretId: null,
+      });
+      prisma._tx.node.update.mockResolvedValue({ id: '1', name: 'test-node' });
+      prisma._tx.nodeAuditLog.create.mockResolvedValue({});
+
+      await service.rotateApiKey('1', 'admin...');
+
+      expect(vault.deleteSecret).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException when not found', async () => {

--- a/src/admin/node-registry.service.ts
+++ b/src/admin/node-registry.service.ts
@@ -56,7 +56,6 @@ export class NodeRegistryService {
           name: dto.name,
           region: dto.region,
           publicKey: dto.publicKey ?? null,
-          apiKey,
           apiKeyHash,
           status: 'pending',
         },
@@ -74,15 +73,16 @@ export class NodeRegistryService {
     });
 
     // Store plaintext key in Vault after transaction commits
+    let apiKeySecretId: string | null = null;
     try {
-      const secretId = await this.vault.createSecret(
+      apiKeySecretId = await this.vault.createSecret(
         apiKey,
         `node_key_${node.id}`,
         `API key for node ${node.name}`,
       );
       await this.prisma.node.update({
         where: { id: node.id },
-        data: { apiKeySecretId: secretId },
+        data: { apiKeySecretId },
       });
     } catch (error) {
       this.logger.warn({
@@ -99,7 +99,12 @@ export class NodeRegistryService {
       region: node.region,
       performedBy: adminKeyPrefix,
     });
-    return node;
+
+    // Return the plaintext key in the response body so the admin caller can
+    // hand it to the node operator. It is NEVER persisted to the nodes row —
+    // the only canonical copies are the hash (for Bearer lookup) and the
+    // Vault secret (for HMAC verification). See issue #59.
+    return { ...node, apiKey, apiKeySecretId };
   }
 
   async listNodes(query: ListNodesQueryDto) {
@@ -243,12 +248,29 @@ export class NodeRegistryService {
     const newApiKey = this.generateApiKey();
     const newApiKeyHash = this.hashApiKey(newApiKey);
 
+    // Vault write FIRST. If this fails, no DB state changes — the node keeps
+    // its old key and remains authenticatable. This is the atomicity fix from
+    // issue #59 (previously: DB updated, then Vault write — if Vault failed,
+    // HMAC auth silently broke because apiKeySecretId pointed at the stale
+    // entry while apiKeyHash had already rotated).
+    //
+    // The name includes a timestamp suffix so consecutive rotations don't
+    // collide with the still-extant previous entry (Vault enforces name
+    // uniqueness). The DB only ever stores the returned secret ID.
+    const newSecretId = await this.vault.createSecret(
+      newApiKey,
+      `node_key_${id}_${Date.now()}`,
+      `API key for node ${existingNode.name} (rotated)`,
+    );
+
+    // Now flip hash + secretId + audit log in a single DB transaction. Either
+    // the whole rotation lands or none of it does.
     const node = await this.prisma.$transaction(async (tx) => {
       const updated = await tx.node.update({
         where: { id },
         data: {
-          apiKey: newApiKey,
           apiKeyHash: newApiKeyHash,
+          apiKeySecretId: newSecretId,
         },
       });
 
@@ -263,27 +285,21 @@ export class NodeRegistryService {
       return updated;
     });
 
-    // Update Vault: create new secret, delete old one
-    try {
-      const secretId = await this.vault.createSecret(
-        newApiKey,
-        `node_key_${id}`,
-        `API key for node ${node.name} (rotated)`,
-      );
-      if (existingNode.apiKeySecretId) {
+    // Best-effort cleanup of the previous Vault secret. A failure here leaves
+    // an orphaned Vault entry but does NOT break the node — it has already
+    // been rotated to the new secret in both DB columns.
+    if (existingNode.apiKeySecretId) {
+      try {
         await this.vault.deleteSecret(existingNode.apiKeySecretId);
+      } catch (error) {
+        this.logger.warn({
+          event: 'vault_delete_failed',
+          action: 'rotate_api_key_cleanup',
+          nodeId: id,
+          staleSecretId: existingNode.apiKeySecretId,
+          error: (error as Error).message,
+        });
       }
-      await this.prisma.node.update({
-        where: { id },
-        data: { apiKeySecretId: secretId },
-      });
-    } catch (error) {
-      this.logger.warn({
-        event: 'vault_write_failed',
-        action: 'rotate_api_key',
-        nodeId: id,
-        error: (error as Error).message,
-      });
     }
 
     this.logger.log({
@@ -291,7 +307,10 @@ export class NodeRegistryService {
       nodeId: id,
       performedBy: adminKeyPrefix,
     });
-    return node;
+
+    // Return the new plaintext key so the admin caller can hand it to the
+    // node operator. Never persisted to the row — see registerNode comment.
+    return { ...node, apiKey: newApiKey };
   }
 
   async deleteNode(id: string) {


### PR DESCRIPTION
## Summary

- Stop writing the plaintext `nodes.api_key` column from service code and make it nullable (phase 1 of phased column drop per CLAUDE.md additive-only rule). Auth paths unchanged: Bearer uses `apiKeyHash`, HMAC uses `apiKeySecretId` via Vault.
- Reorder `rotateApiKey` for atomicity: `Vault.createSecret` first, then a single DB transaction flipping `apiKeyHash` + `apiKeySecretId` + audit log, then best-effort old-secret cleanup. A Vault failure now leaves DB completely unchanged instead of silently breaking HMAC auth.
- Rotated secrets use a `_${Date.now()}` suffix on the Vault name so consecutive rotations don't collide with the still-extant previous entry (Vault enforces name uniqueness — the old swallow-the-error code masked this).

Both endpoint responses (`POST /admin/nodes` and `POST /admin/nodes/:id/rotate-key`) continue to return the plaintext key in the body, sourced from the in-memory generated value. This preserves the API contract — admin tooling captures the key once at issue time, and currently deployed `@opuspopuli/prompt-client` nodes are unaffected (verified by reading the client source — it never reads the prompt-service DB).

Closes #59.

## Test plan

- [x] `pnpm test` — 234 unit tests pass, including 4 new tests covering atomicity (Vault failure leaves DB unchanged, Vault.createSecret runs before DB tx, old-secret cleanup failure non-fatal, plaintext key still returned on Vault failure)
- [x] `pnpm test:integration:docker` — 101 integration tests pass (full Docker stack with new migration applied)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Coverage: `node-registry.service.ts` 98.97% statements / 100% branches / 100% functions / 98.87% lines (above 85/90/90/90 gates)
- [x] Live smoke test against rebuilt local stack:
  - [x] Register a node → response includes `apiKey` (64-char hex), `apiKeyHash`, `apiKeySecretId`
  - [x] DB query confirms `nodes.api_key IS NULL` for newly registered nodes; `api_key_hash` and `api_key_secret_id` populated
  - [x] Returned key works as Bearer against `/prompts/rag` → HTTP 201 with rendered prompt
  - [x] Rotate key → response includes new `apiKey`; old key returns 401; new key returns 201
  - [x] Migration `20260524000000_make_node_api_key_nullable` applied; `nodes_api_key_key` and `nodes_api_key_idx` dropped, `nodes_api_key_hash_idx` retained

## Follow-up

A separate PR will drop the now-unused `nodes.api_key` column. Keeping it nullable in this PR satisfies the "additive only in production" rule so the change can be deployed and verified before the column itself is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)