### PR TITLE
refactor(prompts): descriptor-driven composition, version-history verify, startup drift check

### DIFF
--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -9,6 +9,9 @@ function createMockPrisma() {
       findFirst: jest.fn(),
       findMany: jest.fn(),
     },
+    promptVersionHistory: {
+      findFirst: jest.fn(),
+    },
     promptRequestLog: {
       create: jest.fn(),
     },
@@ -433,28 +436,82 @@ describe('PromptsService', () => {
   });
 
   describe('verifyPrompt', () => {
-    it('should return valid for matching hash', async () => {
+    it('should return valid for a matching (hash, version) pair', async () => {
       const templateText = 'test template';
       const expectedHash = createHash('sha256')
         .update(templateText)
         .digest('hex');
 
-      prisma.promptTemplate.findMany.mockResolvedValue([
-        { name: 'test', templateText, version: 1 },
-      ]);
+      prisma.promptVersionHistory.findFirst.mockResolvedValue({
+        id: 'v-1',
+        templateText,
+        templateHash: expectedHash,
+        version: 1,
+        template: { name: 'test' },
+      });
 
       const result = await service.verifyPrompt(expectedHash, 'v1');
+
       expect(result.valid).toBe(true);
       expect(result.templateName).toBe('test');
+      expect(prisma.promptVersionHistory.findFirst).toHaveBeenCalledWith({
+        where: { templateHash: expectedHash, version: 1 },
+        include: { template: { select: { name: true } } },
+      });
     });
 
-    it('should return invalid for non-matching hash', async () => {
-      prisma.promptTemplate.findMany.mockResolvedValue([
-        { name: 'test', templateText: 'some template', version: 1 },
-      ]);
+    it('should return invalid when no version_history entry matches', async () => {
+      prisma.promptVersionHistory.findFirst.mockResolvedValue(null);
 
       const result = await service.verifyPrompt('badhash', 'v1');
       expect(result.valid).toBe(false);
+    });
+
+    it('should match HISTORICAL versions, not only currently-active templates (issue #60 behavior shift)', async () => {
+      // A v3 hash for a template whose live row is now at v5. The old
+      // implementation scanned promptTemplate.findMany — which only sees
+      // the current row text — and returned invalid. The new query hits
+      // prompt_version_history, which retains every shipped version.
+      const historicalText = 'an older revision of the template';
+      const historicalHash = createHash('sha256')
+        .update(historicalText)
+        .digest('hex');
+
+      prisma.promptVersionHistory.findFirst.mockResolvedValue({
+        id: 'v-old',
+        templateText: historicalText,
+        templateHash: historicalHash,
+        version: 3,
+        template: { name: 'rag' },
+      });
+
+      const result = await service.verifyPrompt(historicalHash, 'v3');
+      expect(result.valid).toBe(true);
+      expect(result.templateName).toBe('rag');
+    });
+
+    it('should short-circuit on malformed promptVersion without touching the DB', async () => {
+      const result = await service.verifyPrompt('any-hash', 'not-a-version');
+
+      expect(result).toEqual({ valid: false });
+      expect(prisma.promptVersionHistory.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('should accept bare numeric promptVersion (no leading "v")', async () => {
+      prisma.promptVersionHistory.findFirst.mockResolvedValue({
+        id: 'v-1',
+        templateText: 'foo',
+        templateHash: 'h',
+        version: 2,
+        template: { name: 'rag' },
+      });
+
+      await service.verifyPrompt('h', '2');
+
+      expect(prisma.promptVersionHistory.findFirst).toHaveBeenCalledWith({
+        where: { templateHash: 'h', version: 2 },
+        include: { template: { select: { name: true } } },
+      });
     });
   });
 
@@ -641,98 +698,40 @@ describe('PromptsService', () => {
     });
   });
 
-  describe('warnOnVariableDrift', () => {
-    // These tests use a simplified "rag" mock with intentional drift — the
-    // warnings they produce are expected and do not indicate a real template issue.
-    function makeTemplate(templateText: string, variables: string[]) {
+  describe('runVariableDriftCheck (startup-once)', () => {
+    // Issue #60 moved drift detection off the request path. These tests
+    // hit the new startup entry point directly. The intentionally-drifted
+    // templates in some tests produce warn logs by design.
+    function makeTemplate(
+      name: string,
+      templateText: string,
+      variables: string[],
+    ) {
+      return { name, templateText, version: 1, isActive: true, variables };
+    }
+
+    function spyLogger() {
       return {
-        id: '1',
-        name: 'rag',
-        templateText,
-        version: 1,
-        isActive: true,
-        variables,
+        warn: jest.spyOn(
+          (service as unknown as { logger: { warn: jest.Mock } }).logger,
+          'warn',
+        ),
+        log: jest.spyOn(
+          (service as unknown as { logger: { log: jest.Mock } }).logger,
+          'log',
+        ),
       };
     }
 
-    it('does not warn when declared variables match placeholders exactly', async () => {
+    it('does NOT run drift detection on the request path (hot path is clean)', async () => {
       const warnSpy = jest.spyOn(
         (service as unknown as { logger: { warn: jest.Mock } }).logger,
         'warn',
       );
+      // Set up a deliberately-drifted template; if the per-request check
+      // had survived the refactor, the rag call below would warn.
       prisma.promptTemplate.findFirst.mockResolvedValue(
-        makeTemplate('{{CONTEXT}} {{QUERY}}', ['CONTEXT', 'QUERY']),
-      );
-      prisma.promptRequestLog.create.mockResolvedValue({});
-
-      await service.getRagPrompt(
-        { context: 'ctx', query: 'q' },
-        'test-key',
-        'ca',
-      );
-
-      expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('drift'),
-      );
-    });
-
-    it('warns when a declared variable has no matching placeholder in template text', async () => {
-      const warnSpy = jest.spyOn(
-        (service as unknown as { logger: { warn: jest.Mock } }).logger,
-        'warn',
-      );
-      prisma.promptTemplate.findFirst.mockResolvedValue(
-        makeTemplate('{{CONTEXT}}', ['CONTEXT', 'QUERY']),
-      );
-      prisma.promptRequestLog.create.mockResolvedValue({});
-
-      await service.getRagPrompt(
-        { context: 'ctx', query: 'q' },
-        'test-key',
-        'ca',
-      );
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('"QUERY" declared but not used'),
-      );
-    });
-
-    it('warns when a placeholder in template text is not declared in variables', async () => {
-      const warnSpy = jest.spyOn(
-        (service as unknown as { logger: { warn: jest.Mock } }).logger,
-        'warn',
-      );
-      prisma.promptTemplate.findFirst.mockResolvedValue(
-        makeTemplate('{{CONTEXT}} {{QUERY}} {{UNDECLARED}}', [
-          'CONTEXT',
-          'QUERY',
-        ]),
-      );
-      prisma.promptRequestLog.create.mockResolvedValue({});
-
-      await service.getRagPrompt(
-        { context: 'ctx', query: 'q' },
-        'test-key',
-        'ca',
-      );
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          '"{{UNDECLARED}}" found in text but not declared',
-        ),
-      );
-    });
-
-    it('skips drift check when variables field is absent (experiment path)', async () => {
-      experiments.resolveExperiment.mockResolvedValue({
-        templateText: '{{CONTEXT}} {{QUERY}} {{ORPHAN}}',
-        version: 2,
-        experimentId: 'exp-1',
-        variantName: 'variant_a',
-      });
-      const warnSpy = jest.spyOn(
-        (service as unknown as { logger: { warn: jest.Mock } }).logger,
-        'warn',
+        makeTemplate('rag', '{{CONTEXT}} {{ORPHAN}}', ['CONTEXT', 'QUERY']),
       );
       prisma.promptRequestLog.create.mockResolvedValue({});
 
@@ -748,6 +747,90 @@ describe('PromptsService', () => {
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('found in text but not declared'),
       );
+    });
+
+    it('logs a clean-pass summary when no drift exists', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([
+        makeTemplate('rag', '{{CONTEXT}} {{QUERY}}', ['CONTEXT', 'QUERY']),
+        makeTemplate('other', '{{X}}', ['X']),
+      ]);
+      const { warn, log } = spyLogger();
+
+      await service.runVariableDriftCheck();
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Variable drift check passed for 2 active template(s)',
+        ),
+      );
+    });
+
+    it('warns when a declared variable has no matching placeholder in template text', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([
+        makeTemplate('rag', '{{CONTEXT}}', ['CONTEXT', 'QUERY']),
+      ]);
+      const { warn } = spyLogger();
+
+      await service.runVariableDriftCheck();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('"QUERY" declared but not used'),
+      );
+    });
+
+    it('warns when a placeholder in template text is not declared in variables', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([
+        makeTemplate('rag', '{{CONTEXT}} {{QUERY}} {{UNDECLARED}}', [
+          'CONTEXT',
+          'QUERY',
+        ]),
+      ]);
+      const { warn } = spyLogger();
+
+      await service.runVariableDriftCheck();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '"{{UNDECLARED}}" found in text but not declared',
+        ),
+      );
+    });
+
+    it('logs an aggregate-warning summary when drift exists', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([
+        makeTemplate('rag', '{{CONTEXT}}', ['CONTEXT', 'QUERY']),
+      ]);
+      const { warn } = spyLogger();
+
+      await service.runVariableDriftCheck();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Variable drift check found 1 issue(s) across 1 active template(s)',
+        ),
+      );
+    });
+
+    it('does not crash the service on a startup DB hiccup', async () => {
+      prisma.promptTemplate.findMany.mockRejectedValue(
+        new Error('DB unreachable'),
+      );
+      const { warn } = spyLogger();
+
+      await expect(service.runVariableDriftCheck()).resolves.not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Variable drift check skipped'),
+      );
+    });
+
+    it('onModuleInit invokes runVariableDriftCheck', async () => {
+      prisma.promptTemplate.findMany.mockResolvedValue([]);
+      const spy = jest.spyOn(service, 'runVariableDriftCheck');
+
+      await service.onModuleInit();
+
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleInit,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../common/prisma.service';
@@ -37,8 +42,38 @@ interface ResolvedTemplate {
   variantName?: string;
 }
 
+/**
+ * Describes how to compose a single prompt endpoint. The compose pipeline
+ * (resolveTemplate → optional auxiliary → interpolate → buildResponse →
+ * logRequest) is identical across all endpoints; descriptors capture only
+ * the per-endpoint variation (issue #60).
+ *
+ * Adding a new prompt type is now: define the DTO + add one descriptor.
+ */
+interface PromptDescriptor<TDto> {
+  /** Audit-log label and the value passed to logRequest. */
+  endpoint: string;
+  /** Resolve the primary template name from the DTO (often a constant). */
+  resolveTemplateName: (dto: TDto) => string;
+  /** Optional fallback template name when the primary doesn't exist. */
+  fallbackTemplateName?: string;
+  /** Build the interpolation variable map from the DTO. */
+  buildVariables: (dto: TDto) => Record<string, string>;
+  /**
+   * Optional auxiliary template. Its text is either injected as a variable
+   * in the main interpolation (`variableName`) or appended after the
+   * interpolated main text (`appendAfter`). Exactly one must be set.
+   */
+  auxiliary?: {
+    resolveTemplateName: (dto: TDto) => string;
+    fallbackTemplateName?: string;
+    variableName?: string;
+    appendAfter?: boolean;
+  };
+}
+
 @Injectable()
-export class PromptsService {
+export class PromptsService implements OnModuleInit {
   private readonly logger = new Logger(PromptsService.name);
 
   /**
@@ -60,48 +95,102 @@ export class PromptsService {
     private readonly experiments: ExperimentsService,
   ) {}
 
+  // ---------------------------------------------------------------------------
+  // Descriptor table — one entry per /prompts/* endpoint.
+  // ---------------------------------------------------------------------------
+
+  private readonly descriptors = {
+    structuralAnalysis: {
+      endpoint: 'structural-analysis',
+      resolveTemplateName: () => 'structural-analysis',
+      buildVariables: (dto: StructuralAnalysisDto) => ({
+        DATA_TYPE: dto.dataType,
+        CONTENT_GOAL: dto.contentGoal,
+        CATEGORY: dto.category ? ` (category: ${dto.category})` : '',
+        HINTS_SECTION: this.renderHintsSection(dto.hints),
+        HTML: dto.html,
+      }),
+      auxiliary: {
+        resolveTemplateName: (dto: StructuralAnalysisDto) =>
+          `structural-schema-${dto.dataType}`,
+        fallbackTemplateName: 'structural-schema-default',
+        variableName: 'SCHEMA_DESCRIPTION',
+      },
+    } satisfies PromptDescriptor<StructuralAnalysisDto>,
+
+    documentAnalysis: {
+      endpoint: 'document-analysis',
+      resolveTemplateName: (dto: DocumentAnalysisDto) =>
+        `document-analysis-${dto.documentType}`,
+      fallbackTemplateName: 'document-analysis-generic',
+      buildVariables: (dto: DocumentAnalysisDto) => ({ TEXT: dto.text }),
+      auxiliary: {
+        resolveTemplateName: () => 'document-analysis-base-instructions',
+        appendAfter: true,
+      },
+    } satisfies PromptDescriptor<DocumentAnalysisDto>,
+
+    rag: {
+      endpoint: 'rag',
+      resolveTemplateName: () => 'rag',
+      buildVariables: (dto: RagDto) => ({
+        CONTEXT: dto.context,
+        QUERY: dto.query,
+      }),
+    } satisfies PromptDescriptor<RagDto>,
+
+    civicsExtraction: {
+      endpoint: 'civics-extraction',
+      resolveTemplateName: () => 'civics-extraction',
+      buildVariables: (dto: CivicsExtractionDto) => ({
+        REGION_ID: dto.regionId,
+        SOURCE_URL: dto.sourceUrl,
+        CONTENT_GOAL: dto.contentGoal,
+        CATEGORY: dto.category ? `Category: ${dto.category}\n` : '',
+        HINTS: this.renderHintsSection(dto.hints),
+        HTML: dto.html,
+      }),
+    } satisfies PromptDescriptor<CivicsExtractionDto>,
+
+    billExtraction: {
+      endpoint: 'bill-extraction',
+      resolveTemplateName: () => 'bill-extraction',
+      buildVariables: (dto: BillExtractionDto) => ({
+        REGION_ID: dto.regionId,
+        SOURCE_URL: dto.sourceUrl,
+        SESSION_YEAR: dto.sessionYear,
+        HTML: dto.html,
+      }),
+    } satisfies PromptDescriptor<BillExtractionDto>,
+
+    billVotesExtraction: {
+      endpoint: 'bill-votes-extraction',
+      resolveTemplateName: () => 'bill-votes-extraction',
+      buildVariables: (dto: BillVotesExtractionDto) => ({
+        REGION_ID: dto.regionId,
+        SOURCE_URL: dto.sourceUrl,
+        SESSION_YEAR: dto.sessionYear,
+        BILL_ID: dto.billId,
+        HTML: dto.html,
+      }),
+    } satisfies PromptDescriptor<BillVotesExtractionDto>,
+  };
+
+  // ---------------------------------------------------------------------------
+  // Public API — one one-liner per endpoint. Each delegates to composePrompt.
+  // ---------------------------------------------------------------------------
+
   async getStructuralAnalysisPrompt(
     dto: StructuralAnalysisDto,
     apiKey: string,
     region: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate('structural-analysis', apiKey);
-
-    // Schema/auxiliary templates always use default (no A/B)
-    const schemaTemplate = await this.getActiveTemplate(
-      `structural-schema-${dto.dataType}`,
-      'structural-schema-default',
-    );
-    this.warnOnVariableDrift(schemaTemplate);
-
-    const hintsSection = dto.hints?.length
-      ? '## Hints from the region author\n' +
-        dto.hints.map((h) => '- ' + h).join('\n') +
-        '\n'
-      : '';
-
-    const promptText = this.interpolate(template.templateText, {
-      DATA_TYPE: dto.dataType,
-      CONTENT_GOAL: dto.contentGoal,
-      CATEGORY: dto.category ? ` (category: ${dto.category})` : '',
-      HINTS_SECTION: hintsSection,
-      SCHEMA_DESCRIPTION: schemaTemplate.templateText,
-      HTML: dto.html,
-    });
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'structural-analysis',
-      template.version,
+    return this.composePrompt(
+      this.descriptors.structuralAnalysis,
+      dto,
       apiKey,
       region,
-      template.experimentId,
-      template.variantName,
     );
-
-    return response;
   }
 
   async getDocumentAnalysisPrompt(
@@ -109,36 +198,20 @@ export class PromptsService {
     apiKey: string,
     region: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate(
-      `document-analysis-${dto.documentType}`,
-      apiKey,
-      'document-analysis-generic',
-    );
-
-    // Base instructions always use default (no A/B)
-    const baseInstructions = await this.getActiveTemplate(
-      'document-analysis-base-instructions',
-    );
-    this.warnOnVariableDrift(baseInstructions);
-
-    const promptText =
-      this.interpolate(template.templateText, { TEXT: dto.text }) +
-      '\n' +
-      baseInstructions.templateText;
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'document-analysis',
-      template.version,
+    return this.composePrompt(
+      this.descriptors.documentAnalysis,
+      dto,
       apiKey,
       region,
-      template.experimentId,
-      template.variantName,
     );
+  }
 
-    return response;
+  async getRagPrompt(
+    dto: RagDto,
+    apiKey: string,
+    region: string,
+  ): Promise<PromptServiceResponse> {
+    return this.composePrompt(this.descriptors.rag, dto, apiKey, region);
   }
 
   /**
@@ -153,36 +226,12 @@ export class PromptsService {
     apiKey: string,
     region: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate('civics-extraction', apiKey);
-
-    const hintsSection = dto.hints?.length
-      ? '## Hints from the region author\n' +
-        dto.hints.map((h) => '- ' + h).join('\n') +
-        '\n'
-      : '';
-
-    const promptText = this.interpolate(template.templateText, {
-      REGION_ID: dto.regionId,
-      SOURCE_URL: dto.sourceUrl,
-      CONTENT_GOAL: dto.contentGoal,
-      CATEGORY: dto.category ? `Category: ${dto.category}\n` : '',
-      HINTS: hintsSection,
-      HTML: dto.html,
-    });
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'civics-extraction',
-      template.version,
+    return this.composePrompt(
+      this.descriptors.civicsExtraction,
+      dto,
       apiKey,
       region,
-      template.experimentId,
-      template.variantName,
     );
-
-    return response;
   }
 
   async getBillExtractionPrompt(
@@ -190,28 +239,12 @@ export class PromptsService {
     apiKey: string,
     region: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate('bill-extraction', apiKey);
-
-    const promptText = this.interpolate(template.templateText, {
-      REGION_ID: dto.regionId,
-      SOURCE_URL: dto.sourceUrl,
-      SESSION_YEAR: dto.sessionYear,
-      HTML: dto.html,
-    });
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'bill-extraction',
-      template.version,
+    return this.composePrompt(
+      this.descriptors.billExtraction,
+      dto,
       apiKey,
       region,
-      template.experimentId,
-      template.variantName,
     );
-
-    return response;
   }
 
   async getBillVotesExtractionPrompt(
@@ -219,59 +252,12 @@ export class PromptsService {
     apiKey: string,
     region: string,
   ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate(
-      'bill-votes-extraction',
-      apiKey,
-    );
-
-    const promptText = this.interpolate(template.templateText, {
-      REGION_ID: dto.regionId,
-      SOURCE_URL: dto.sourceUrl,
-      SESSION_YEAR: dto.sessionYear,
-      BILL_ID: dto.billId,
-      HTML: dto.html,
-    });
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'bill-votes-extraction',
-      template.version,
+    return this.composePrompt(
+      this.descriptors.billVotesExtraction,
+      dto,
       apiKey,
       region,
-      template.experimentId,
-      template.variantName,
     );
-
-    return response;
-  }
-
-  async getRagPrompt(
-    dto: RagDto,
-    apiKey: string,
-    region: string,
-  ): Promise<PromptServiceResponse> {
-    const template = await this.resolveTemplate('rag', apiKey);
-
-    const promptText = this.interpolate(template.templateText, {
-      CONTEXT: dto.context,
-      QUERY: dto.query,
-    });
-
-    const response = this.buildResponse(template);
-    response.promptText = promptText;
-
-    await this.logRequest(
-      'rag',
-      template.version,
-      apiKey,
-      region,
-      template.experimentId,
-      template.variantName,
-    );
-
-    return response;
   }
 
   /**
@@ -295,23 +281,144 @@ export class PromptsService {
     };
   }
 
+  /**
+   * Verify that a (hash, version) pair matches a known template version.
+   *
+   * Queries the indexed `prompt_version_history.templateHash` column rather
+   * than recomputing SHA-256 over every active template per call (issue #60).
+   *
+   * Behavior shift (intentional, called out in #60 PR):
+   *   - Matches HISTORICAL versions too, not only the currently-active
+   *     template text. A previously-shipped hash now returns valid=true
+   *     instead of valid=false.
+   *   - Malformed `promptVersion` (anything not parseable as `v<int>`)
+   *     short-circuits to `{ valid: false }` instead of scanning every
+   *     template in the DB.
+   */
   async verifyPrompt(
     promptHash: string,
     promptVersion: string,
   ): Promise<VerifyResult> {
-    const versionNum = Number.parseInt(promptVersion.replace('v', ''), 10);
+    const versionNum = Number.parseInt(promptVersion.replace(/^v/, ''), 10);
+    if (Number.isNaN(versionNum)) {
+      return { valid: false };
+    }
 
-    const templates = await this.prisma.promptTemplate.findMany({
-      where: { version: Number.isNaN(versionNum) ? undefined : versionNum },
+    const entry = await this.prisma.promptVersionHistory.findFirst({
+      where: { templateHash: promptHash, version: versionNum },
+      include: { template: { select: { name: true } } },
     });
 
-    for (const t of templates) {
-      if (this.hash(t.templateText) === promptHash) {
-        return { valid: true, templateName: t.name };
+    if (!entry) {
+      return { valid: false };
+    }
+
+    return { valid: true, templateName: entry.template.name };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Startup — variable drift self-check
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scan all active templates for placeholder/variable drift once at boot
+   * and log a summary. This was previously done on every request
+   * (`warnOnVariableDrift`); moved here per issue #60 so the hot path
+   * doesn't pay for a build-time validation check.
+   *
+   * Drift kinds:
+   *   - declared-but-unused: a name in `variables[]` has no matching
+   *     `{{NAME}}` in `templateText`.
+   *   - undeclared placeholder: a `{{NAME}}` in the text isn't in
+   *     `variables[]` — callers may pass it but won't be type-checked.
+   */
+  async onModuleInit(): Promise<void> {
+    await this.runVariableDriftCheck();
+  }
+
+  async runVariableDriftCheck(): Promise<void> {
+    try {
+      const templates = await this.prisma.promptTemplate.findMany({
+        where: { isActive: true },
+      });
+
+      let warningCount = 0;
+      for (const t of templates) {
+        warningCount += this.warnOnVariableDrift({
+          templateText: t.templateText,
+          version: t.version,
+          name: t.name,
+          variables: t.variables,
+        });
+      }
+
+      if (warningCount === 0) {
+        this.logger.log(
+          `Variable drift check passed for ${templates.length} active template(s)`,
+        );
+      } else {
+        this.logger.warn(
+          `Variable drift check found ${warningCount} issue(s) across ${templates.length} active template(s) — see prior warn lines`,
+        );
+      }
+    } catch (err) {
+      // Don't crash the service on a startup DB hiccup — this check is
+      // diagnostic. The next request will surface real DB issues.
+      this.logger.warn(
+        `Variable drift check skipped: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private composition pipeline
+  // ---------------------------------------------------------------------------
+
+  private async composePrompt<TDto>(
+    descriptor: PromptDescriptor<TDto>,
+    dto: TDto,
+    apiKey: string,
+    region: string,
+  ): Promise<PromptServiceResponse> {
+    const template = await this.resolveTemplate(
+      descriptor.resolveTemplateName(dto),
+      apiKey,
+      descriptor.fallbackTemplateName,
+    );
+
+    const variables = descriptor.buildVariables(dto);
+    let auxiliaryText: string | undefined;
+
+    if (descriptor.auxiliary) {
+      const aux = await this.getActiveTemplate(
+        descriptor.auxiliary.resolveTemplateName(dto),
+        descriptor.auxiliary.fallbackTemplateName,
+      );
+      if (descriptor.auxiliary.variableName) {
+        variables[descriptor.auxiliary.variableName] = aux.templateText;
+      } else if (descriptor.auxiliary.appendAfter) {
+        auxiliaryText = aux.templateText;
       }
     }
 
-    return { valid: false };
+    let promptText = this.interpolate(template.templateText, variables);
+    if (auxiliaryText !== undefined) {
+      promptText = promptText + '\n' + auxiliaryText;
+    }
+
+    const response = this.buildResponse(template);
+    response.promptText = promptText;
+
+    await this.logRequest(
+      descriptor.endpoint,
+      template.version,
+      apiKey,
+      region,
+      template.experimentId,
+      template.variantName,
+    );
+
+    return response;
   }
 
   private async resolveTemplate(
@@ -325,22 +432,18 @@ export class PromptsService {
       apiKey,
     );
     if (experimentResult) {
-      const resolved: ResolvedTemplate = {
+      return {
         templateText: experimentResult.templateText,
         version: experimentResult.version,
         name,
-        // variables not available from experiment variant path
+        // variables not available on the experiment path; drift check
+        // runs at startup over canonical templates instead.
         experimentId: experimentResult.experimentId,
         variantName: experimentResult.variantName,
       };
-      this.warnOnVariableDrift(resolved);
-      return resolved;
     }
 
-    // Fall back to default active template
-    const resolved = await this.getActiveTemplate(name, fallbackName);
-    this.warnOnVariableDrift(resolved);
-    return resolved;
+    return this.getActiveTemplate(name, fallbackName);
   }
 
   private async getActiveTemplate(
@@ -369,6 +472,15 @@ export class PromptsService {
     };
   }
 
+  private renderHintsSection(hints?: string[]): string {
+    if (!hints?.length) return '';
+    return (
+      '## Hints from the region author\n' +
+      hints.map((h) => '- ' + h).join('\n') +
+      '\n'
+    );
+  }
+
   private extractPlaceholders(text: string): Set<string> {
     const found = new Set<string>();
     for (const match of text.matchAll(/\{\{([A-Z_]+)\}\}/g)) {
@@ -377,15 +489,24 @@ export class PromptsService {
     return found;
   }
 
-  private warnOnVariableDrift(template: ResolvedTemplate): void {
-    if (!template.variables) return;
+  /**
+   * Compare a template's declared variables[] against the {{PLACEHOLDERS}}
+   * actually present in its text. Logs a warn line per mismatch. Returns
+   * the number of warnings emitted (caller aggregates).
+   *
+   * Invoked once at startup via runVariableDriftCheck — not per request.
+   */
+  private warnOnVariableDrift(template: ResolvedTemplate): number {
+    if (!template.variables) return 0;
     const inText = this.extractPlaceholders(template.templateText);
     const declared = new Set(template.variables);
+    let warnings = 0;
     for (const v of declared) {
       if (!inText.has(v)) {
         this.logger.warn(
           `Template "${template.name}": variable "${v}" declared but not used in template text`,
         );
+        warnings += 1;
       }
     }
     for (const v of inText) {
@@ -393,8 +514,10 @@ export class PromptsService {
         this.logger.warn(
           `Template "${template.name}": placeholder "{{${v}}}" found in text but not declared in variables`,
         );
+        warnings += 1;
       }
     }
+    return warnings;
   }
 
   private interpolate(


### PR DESCRIPTION
## Summary

Three related cleanups in the prompts module from the end-to-end review, all preserving the wire contract (109 integration tests stay green).

- **Collapse six handlers into one** — `getStructuralAnalysisPrompt`, `getDocumentAnalysisPrompt`, `getRagPrompt`, `getCivicsExtractionPrompt`, `getBillExtractionPrompt`, `getBillVotesExtractionPrompt` were near-identical: resolve template → optional auxiliary → interpolate → buildResponse → logRequest. Now a single `composePrompt(descriptor, dto, apiKey, region)` runs the pipeline, and each endpoint is a one-line public method delegating to it via a `PromptDescriptor` table. Adding a seventh prompt type is now a DTO + one descriptor entry instead of ~30 lines of duplicated service code + ~15 lines of duplicated controller code.

- **`verifyPrompt`** — rewritten to query `prompt_version_history.templateHash` with a single indexed lookup instead of loading every active template and recomputing SHA-256 in-process.

- **Variable drift check off the request path** — previously `warnOnVariableDrift` ran on every prompt call (allocating, logging warnings nobody acts on at runtime, and silently skipping experiment variants). Now `runVariableDriftCheck()` runs once at boot via `OnModuleInit`, scans all active templates, and logs an aggregate pass/issue summary. Per-template warnings are preserved.

Closes #60.

## Compatibility note — verifyPrompt semantic shifts

Two intentional behavior changes worth calling out:

1. **Matches historical versions, not only currently-active text.** A previously-shipped hash now returns `valid: true` instead of `valid: false`. The old implementation scanned `promptTemplate.findMany`, which only sees the row's current text. The new implementation hits `prompt_version_history`, which retains every shipped version. This is arguably more correct (legitimate historical verification works) but is a behavior change for anyone relying on strict-current-only semantics.

2. **Malformed `promptVersion` short-circuits to `{valid: false}` immediately.** Previously, an unparseable version would scan every template in the DB. Now an early `Number.isNaN(versionNum)` check returns false without a query.

Neither change affects the request/response shape — both still return `{valid: boolean, templateName?: string}`. Just the semantics of when `valid` is true.

## Test plan

- [x] `pnpm test` — **251 unit tests pass** (was 245, added 6 new: 4 for `verifyPrompt` covering historical-match, malformed input, bare-numeric version; 2 for `runVariableDriftCheck` covering clean-pass summary, aggregate-issue summary, and `onModuleInit` wiring)
- [x] `pnpm test:integration:docker` — **109 integration tests pass unchanged**. These are the byte-equivalence safety net: every prompt endpoint's wire response is asserted hash-stable, so a refactor that quietly changed the composition pipeline would break here. They didn't.
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Live smoke against the rebuilt local stack:
  - [x] Startup logs show `Variable drift check passed for 21 active template(s)` (drift check moved off the hot path, runs once at boot)
  - [x] All 5 main prompt endpoints (rag, civics-extraction, bill-extraction, structural-analysis, bill-votes-extraction) return well-formed responses with `promptVersion: v1` and correct `promptHash`
  - [x] `POST /prompts/verify` with a valid hash → `{"valid":true,"templateName":"rag"}`
  - [x] `POST /prompts/verify` with `promptVersion: "not-a-version"` → `{"valid":false}` (returns immediately, no DB hit)

## What's NOT in this PR

The original review issue also flagged that the experiment-variant path skips drift checking because `variables` isn't loaded there. That's still true after this PR — the startup check now scans the canonical templates only, not variants. Catching drift on admin-created variants would belong in the admin POST/PATCH path (separate concern, separate PR if we want it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)