### PR TITLE
feat(prompts): client integration support — caching endpoint, HMAC canonicalization, hygiene

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -239,6 +239,21 @@ Certified nodes have a `certificationExpiresAt` timestamp (default: 365 days fro
 - The admin must run `/admin/nodes/:id/recertify` to restore access
 - Certification expiry does **not** invalidate or rotate the node's API key
 
+## Operational Surfaces
+
+### `/metrics` (Prometheus scrape endpoint)
+
+The `/metrics` endpoint is **intentionally unauthenticated** so a Prometheus scraper can pull counters without holding an admin or node API key. This is the standard Prometheus deployment pattern and matches what every observability stack expects.
+
+**Security model**: `/metrics` is assumed to be reachable **only from inside the cluster network** (or behind an ingress ACL that allows the scraper's source CIDR and nothing else). The service does not gate it because gating would break the scrape.
+
+If you deploy the service on a public address, you must restrict `/metrics` at the network or ingress layer:
+- Kubernetes: NetworkPolicy allowing only the Prometheus namespace/pod
+- Docker Compose: do not publish port 3210 publicly, or add a reverse-proxy ACL
+- Cloud (CF / ECS / Cloud Run): block `/metrics` at the load balancer
+
+Metric labels never include API keys, admin tokens, node IDs, or template text — only endpoint paths, HTTP methods, and status codes — so the scrape body itself does not contain secrets.
+
 ## Known Limitations
 
 1. **No mutual TLS**: Node-to-service communication uses Bearer tokens over HTTPS, not mTLS. This is acceptable for the current deployment model (internal Docker network) but should be revisited for multi-host federation.

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -38,6 +38,15 @@ services:
       # serial test execution. Production behavior is verified separately by
       # the hardening unit tests + live smoke test.
       ADMIN_THROTTLE_LIMIT: '1000'
+      # Raise the global IP throttle for the same reason: the integration
+      # suite fires 100+ requests from a single container IP, well past the
+      # production default of 60/min.
+      GLOBAL_THROTTLE_LIMIT: '10000'
+      # Raise the per-route prompt POST throttle similarly. The default 30/min
+      # is hit by the cumulative POST count across all prompts integration
+      # suites running serially from one container IP. Production behavior
+      # is verified by the dedicated rate-limiting/throttle.integration.spec.ts.
+      PROMPT_THROTTLE_LIMIT: '10000'
       PORT: 3200
     depends_on:
       opuspopuli-prompts-db-test:

--- a/src/admin/node-registry.controller.spec.ts
+++ b/src/admin/node-registry.controller.spec.ts
@@ -49,7 +49,7 @@ describe('NodeRegistryController', () => {
     jest.spyOn(service, 'registerNode').mockResolvedValue(expected as never);
 
     const result = await controller.register(dto, {
-      adminKey: 'admin-test-key-123',
+      adminKeyPrefix: 'admin-te...',
     });
 
     expect(service.registerNode).toHaveBeenCalledWith(dto, 'admin-te...');
@@ -106,7 +106,7 @@ describe('NodeRegistryController', () => {
     jest.spyOn(service, 'certifyNode').mockResolvedValue(expected as never);
 
     const result = await controller.certify('1', dto, {
-      adminKey: 'admin-test-key-123',
+      adminKeyPrefix: 'admin-te...',
     });
 
     expect(service.certifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
@@ -119,7 +119,7 @@ describe('NodeRegistryController', () => {
     jest.spyOn(service, 'decertifyNode').mockResolvedValue(expected as never);
 
     const result = await controller.decertify('1', dto, {
-      adminKey: 'admin-test-key-123',
+      adminKeyPrefix: 'admin-te...',
     });
 
     expect(service.decertifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
@@ -132,7 +132,7 @@ describe('NodeRegistryController', () => {
     jest.spyOn(service, 'recertifyNode').mockResolvedValue(expected as never);
 
     const result = await controller.recertify('1', dto, {
-      adminKey: 'admin-test-key-123',
+      adminKeyPrefix: 'admin-te...',
     });
 
     expect(service.recertifyNode).toHaveBeenCalledWith('1', dto, 'admin-te...');
@@ -144,7 +144,7 @@ describe('NodeRegistryController', () => {
     jest.spyOn(service, 'rotateApiKey').mockResolvedValue(expected as never);
 
     const result = await controller.rotateKey('1', {
-      adminKey: 'admin-test-key-123',
+      adminKeyPrefix: 'admin-te...',
     });
 
     expect(service.rotateApiKey).toHaveBeenCalledWith('1', 'admin-te...');
@@ -178,7 +178,7 @@ describe('NodeRegistryController', () => {
         .mockRejectedValue(new NotFoundException());
 
       await expect(
-        controller.certify('not-found', {}, { adminKey: 'admin-key-12345' }),
+        controller.certify('not-found', {}, { adminKeyPrefix: 'admin-ke...' }),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -190,7 +190,7 @@ describe('NodeRegistryController', () => {
         );
 
       await expect(
-        controller.certify('1', {}, { adminKey: 'admin-key-12345' }),
+        controller.certify('1', {}, { adminKeyPrefix: 'admin-ke...' }),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -203,7 +203,7 @@ describe('NodeRegistryController', () => {
         controller.decertify(
           'not-found',
           { reason: 'test' },
-          { adminKey: 'admin-key-12345' },
+          { adminKeyPrefix: 'admin-ke...' },
         ),
       ).rejects.toThrow(NotFoundException);
     });

--- a/src/admin/node-registry.controller.ts
+++ b/src/admin/node-registry.controller.ts
@@ -49,9 +49,11 @@ export class NodeRegistryController {
     status: 201,
     description: 'Node registered with generated API key',
   })
-  async register(@Body() dto: CreateNodeDto, @Req() req: { adminKey: string }) {
-    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
-    return this.nodeRegistry.registerNode(dto, adminKeyPrefix);
+  async register(
+    @Body() dto: CreateNodeDto,
+    @Req() req: { adminKeyPrefix: string },
+  ) {
+    return this.nodeRegistry.registerNode(dto, req.adminKeyPrefix);
   }
 
   @Get()
@@ -86,10 +88,9 @@ export class NodeRegistryController {
   async certify(
     @Param('id') id: string,
     @Body() dto: CertifyNodeDto,
-    @Req() req: { adminKey: string },
+    @Req() req: { adminKeyPrefix: string },
   ) {
-    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
-    return this.nodeRegistry.certifyNode(id, dto, adminKeyPrefix);
+    return this.nodeRegistry.certifyNode(id, dto, req.adminKeyPrefix);
   }
 
   @Post(':id/decertify')
@@ -98,10 +99,9 @@ export class NodeRegistryController {
   async decertify(
     @Param('id') id: string,
     @Body() dto: DecertifyNodeDto,
-    @Req() req: { adminKey: string },
+    @Req() req: { adminKeyPrefix: string },
   ) {
-    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
-    return this.nodeRegistry.decertifyNode(id, dto, adminKeyPrefix);
+    return this.nodeRegistry.decertifyNode(id, dto, req.adminKeyPrefix);
   }
 
   @Post(':id/recertify')
@@ -110,18 +110,19 @@ export class NodeRegistryController {
   async recertify(
     @Param('id') id: string,
     @Body() dto: CertifyNodeDto,
-    @Req() req: { adminKey: string },
+    @Req() req: { adminKeyPrefix: string },
   ) {
-    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
-    return this.nodeRegistry.recertifyNode(id, dto, adminKeyPrefix);
+    return this.nodeRegistry.recertifyNode(id, dto, req.adminKeyPrefix);
   }
 
   @Post(':id/rotate-key')
   @ApiOperation({ summary: 'Rotate a node API key' })
   @ApiResponse({ status: 404, description: NODE_NOT_FOUND })
-  async rotateKey(@Param('id') id: string, @Req() req: { adminKey: string }) {
-    const adminKeyPrefix = req.adminKey.slice(0, 8) + '...';
-    return this.nodeRegistry.rotateApiKey(id, adminKeyPrefix);
+  async rotateKey(
+    @Param('id') id: string,
+    @Req() req: { adminKeyPrefix: string },
+  ) {
+    return this.nodeRegistry.rotateApiKey(id, req.adminKeyPrefix);
   }
 
   @Delete(':id')

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,11 +12,21 @@ import { AdminModule } from './admin/admin.module';
 import { ExperimentsModule } from './experiments/experiments.module';
 import { MetricsModule } from './metrics/metrics.module';
 
+// Global IP-based throttle. Default 60/min covers a single legitimate
+// user's traffic comfortably while still bounding brute-force attempts.
+// Raised in integration test envs (single container IP → single bucket
+// for the entire suite) via GLOBAL_THROTTLE_LIMIT. Mirrors the
+// ADMIN_THROTTLE_LIMIT pattern used for admin endpoints.
+const GLOBAL_THROTTLE_LIMIT = Number.parseInt(
+  process.env.GLOBAL_THROTTLE_LIMIT ?? '60',
+  10,
+);
+
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     ScheduleModule.forRoot(),
-    ThrottlerModule.forRoot([{ ttl: 60_000, limit: 60 }]),
+    ThrottlerModule.forRoot([{ ttl: 60_000, limit: GLOBAL_THROTTLE_LIMIT }]),
     PrismaModule,
     HealthModule,
     PromptsModule,

--- a/src/auth/admin-key.guard.spec.ts
+++ b/src/auth/admin-key.guard.spec.ts
@@ -64,6 +64,20 @@ describe('AdminKeyGuard', () => {
     expect(request.adminKey).toBe('admin-key-2');
   });
 
+  it('should attach adminKeyPrefix (8-char masked) to request on success', () => {
+    // Centralizes the prefix derivation so controllers don't slice the
+    // token independently — issue #61 finding 2.
+    const request: Record<string, unknown> = {
+      headers: { authorization: 'Bearer admin-key-2' },
+    };
+    const ctx = {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext;
+
+    guard.canActivate(ctx);
+    expect(request.adminKeyPrefix).toBe('admin-ke...');
+  });
+
   describe('Vault key loading', () => {
     it('should load admin keys from Vault on init', async () => {
       mockVault.getSecretsByPrefix.mockResolvedValue([

--- a/src/auth/admin-key.guard.ts
+++ b/src/auth/admin-key.guard.ts
@@ -60,6 +60,10 @@ export class AdminKeyGuard implements CanActivate, OnModuleInit {
     }
 
     request.adminKey = token;
+    // Centralized so controllers/services don't each slice the token
+    // independently (issue #61 finding 2). The masked prefix is what
+    // lands in audit logs as `performedBy`.
+    request.adminKeyPrefix = token.slice(0, 8) + '...';
     return true;
   }
 }

--- a/src/auth/api-key.guard.spec.ts
+++ b/src/auth/api-key.guard.spec.ts
@@ -38,11 +38,19 @@ function createMockVault() {
   };
 }
 
-function createMockContext(headers: Record<string, string> = {}) {
+function createMockContext(
+  headers: Record<string, string> = {},
+  pathOverrides: { path?: string; originalUrl?: string } = {},
+) {
+  const path = pathOverrides.path ?? '/prompts/rag';
   const request: Record<string, unknown> = {
     headers,
     method: 'POST',
-    path: '/prompts/rag',
+    path,
+    // Mirror real Express, which always sets originalUrl. Tests can pass a
+    // different value via overrides to exercise the canonical-vs-legacy
+    // path matching introduced in #61.
+    originalUrl: pathOverrides.originalUrl ?? path,
   };
 
   return {
@@ -498,6 +506,144 @@ describe('ApiKeyGuard', () => {
 
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(request.nodeId).toBe(nodeId);
+    });
+
+    describe('path canonicalization — transitional accept-both-forms (issue #61)', () => {
+      // The server initially accepts both the canonical form (originalUrl,
+      // with query string) and the legacy form (path, no query string) so
+      // currently-deployed @opuspopuli/prompt-client versions keep working
+      // during rollout. A follow-up PR tightens to canonical-only after
+      // the `hmac_legacy_path_signature` metric drops to zero.
+
+      const body = '{"x":1}';
+      const timestamp = () => Math.floor(Date.now() / 1000).toString();
+
+      beforeEach(() => {
+        mockPrisma.node.findUnique.mockResolvedValue(certifiedNode);
+        mockVault.getSecret.mockResolvedValue(apiKey);
+      });
+
+      function buildSignedHeaders(
+        ts: string,
+        method: string,
+        signedPath: string,
+        b: string,
+      ) {
+        return {
+          'x-hmac-signature': computeHmac(apiKey, ts, method, signedPath, b),
+          'x-hmac-timestamp': ts,
+          'x-hmac-key-id': nodeId,
+          'content-type': 'application/json',
+        };
+      }
+
+      it('accepts the canonical form (originalUrl with query string)', async () => {
+        const ts = timestamp();
+        const canonical = '/admin/nodes?status=certified';
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', canonical, body),
+          { path: '/admin/nodes', originalUrl: canonical },
+        );
+        // Re-attach rawBody so HMAC body hash matches
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      });
+
+      it('accepts the legacy form (path-only) during transition', async () => {
+        const ts = timestamp();
+        const canonical = '/admin/nodes?status=certified';
+        const legacy = '/admin/nodes';
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', legacy, body),
+          { path: legacy, originalUrl: canonical },
+        );
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+      });
+
+      it('logs `hmac_legacy_path_signature` when the legacy form is used', async () => {
+        const warnSpy = jest.spyOn(
+          (guard as unknown as { logger: { warn: jest.Mock } }).logger,
+          'warn',
+        );
+        const ts = timestamp();
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', '/admin/nodes', body),
+          {
+            path: '/admin/nodes',
+            originalUrl: '/admin/nodes?status=certified',
+          },
+        );
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+
+        await guard.canActivate(ctx);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: 'hmac_legacy_path_signature',
+            keyId: nodeId,
+          }),
+        );
+      });
+
+      it('does NOT log the legacy event when canonical signature succeeds', async () => {
+        const warnSpy = jest.spyOn(
+          (guard as unknown as { logger: { warn: jest.Mock } }).logger,
+          'warn',
+        );
+        const ts = timestamp();
+        const canonical = '/admin/nodes?status=certified';
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', canonical, body),
+          { path: '/admin/nodes', originalUrl: canonical },
+        );
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+
+        await guard.canActivate(ctx);
+
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.objectContaining({ event: 'hmac_legacy_path_signature' }),
+        );
+      });
+
+      it('rejects a signature that matches NEITHER form', async () => {
+        const ts = timestamp();
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', '/wrong/path', body),
+          {
+            path: '/admin/nodes',
+            originalUrl: '/admin/nodes?status=certified',
+          },
+        );
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+
+        await expect(guard.canActivate(ctx)).rejects.toThrow(
+          UnauthorizedException,
+        );
+      });
+
+      it('does NOT attempt legacy fallback when originalUrl equals path (no query)', async () => {
+        // When the request has no query string, canonical == legacy, so
+        // there's no second candidate to compute. Saves the work on the
+        // happy path (prompts endpoints today don't use query strings).
+        const ts = timestamp();
+        const { ctx } = createMockContext(
+          buildSignedHeaders(ts, 'POST', '/prompts/rag', body),
+          { path: '/prompts/rag', originalUrl: '/prompts/rag' },
+        );
+        ctx.switchToHttp().getRequest().rawBody = Buffer.from(body);
+        const warnSpy = jest.spyOn(
+          (guard as unknown as { logger: { warn: jest.Mock } }).logger,
+          'warn',
+        );
+
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.objectContaining({ event: 'hmac_legacy_path_signature' }),
+        );
+      });
     });
   });
 });

--- a/src/auth/api-key.guard.ts
+++ b/src/auth/api-key.guard.ts
@@ -67,6 +67,81 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
     return createHash('sha256').update(token).digest('hex');
   }
 
+  private computeHmacSignature(
+    apiKey: string,
+    timestamp: string,
+    method: string,
+    path: string,
+    bodyHash: string,
+  ): string {
+    const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+    return createHmac('sha256', apiKey)
+      .update(signatureString)
+      .digest('base64');
+  }
+
+  /**
+   * Verify the HMAC signature against the canonical path form, falling
+   * back to the legacy form during the transitional release (issue #61).
+   * Throws UnauthorizedException when neither matches; emits the
+   * `hmac_legacy_path_signature` warn event when only the legacy form
+   * matches, so ops can monitor when to ship the follow-up tightening PR.
+   */
+  private verifyHmacSignature(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    request: any,
+    apiKey: string,
+    signature: string,
+    timestamp: string,
+    keyId: string,
+  ): void {
+    const rawBody = request.rawBody
+      ? Buffer.from(request.rawBody).toString('utf8')
+      : '';
+    const bodyHash = createHash('sha256').update(rawBody).digest('hex');
+    const method = request.method.toUpperCase();
+    const canonicalPath = request.originalUrl || request.url;
+    const legacyPath = request.path || request.url;
+
+    const canonicalSig = this.computeHmacSignature(
+      apiKey,
+      timestamp,
+      method,
+      canonicalPath,
+      bodyHash,
+    );
+    if (safeCompare(canonicalSig, signature)) return;
+
+    // Only compute the legacy candidate when the canonical form failed and
+    // the two forms actually differ — skips the work on the happy path.
+    if (canonicalPath !== legacyPath) {
+      const legacySig = this.computeHmacSignature(
+        apiKey,
+        timestamp,
+        method,
+        legacyPath,
+        bodyHash,
+      );
+      if (safeCompare(legacySig, signature)) {
+        this.logger.warn({
+          event: 'hmac_legacy_path_signature',
+          keyId,
+          canonicalPath,
+          legacyPath,
+        });
+        return;
+      }
+    }
+
+    this.logger.warn({
+      event: 'auth_failed',
+      method: 'hmac',
+      reason: 'signature_mismatch',
+      keyId,
+    });
+    throw new UnauthorizedException('Invalid HMAC signature');
+  }
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
@@ -173,28 +248,7 @@ export class ApiKeyGuard implements CanActivate, OnModuleInit {
       throw new UnauthorizedException('Failed to retrieve node key');
     }
 
-    // Compute expected signature
-    const rawBody = request.rawBody
-      ? Buffer.from(request.rawBody).toString('utf8')
-      : '';
-    const bodyHash = createHash('sha256').update(rawBody).digest('hex');
-    const method = request.method.toUpperCase();
-    const path = request.path || request.url;
-
-    const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
-    const expectedSignature = createHmac('sha256', apiKey)
-      .update(signatureString)
-      .digest('base64');
-
-    if (!safeCompare(expectedSignature, signature)) {
-      this.logger.warn({
-        event: 'auth_failed',
-        method: 'hmac',
-        reason: 'signature_mismatch',
-        keyId,
-      });
-      throw new UnauthorizedException('Invalid HMAC signature');
-    }
+    this.verifyHmacSignature(request, apiKey, signature, timestamp, keyId);
 
     // Propagate the authenticated secret so downstream audit logging
     // (apiKeyPrefix) can record which key served the request, matching

--- a/src/prompts/prompts.controller.spec.ts
+++ b/src/prompts/prompts.controller.spec.ts
@@ -28,6 +28,7 @@ describe('PromptsController', () => {
             getBillVotesExtractionPrompt: jest.fn(),
             verifyPrompt: jest.fn(),
             getPromptHash: jest.fn(),
+            getPromptTemplate: jest.fn(),
           },
         },
         {
@@ -212,6 +213,33 @@ describe('PromptsController', () => {
     const result = await controller.hash('structural-analysis');
 
     expect(service.getPromptHash).toHaveBeenCalledWith('structural-analysis');
+    expect(result).toEqual(expected);
+  });
+
+  it('should call getPromptTemplate with the name and request context (issue #66)', async () => {
+    const expected = {
+      name: 'bill-extraction',
+      templateText: 'tmpl',
+      variables: ['REGION_ID', 'HTML'],
+      promptHash: 'h',
+      promptVersion: 'v2',
+      expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+      experimentId: null,
+      variantName: null,
+    };
+
+    jest.spyOn(service, 'getPromptTemplate').mockResolvedValue(expected);
+
+    const result = await controller.template('bill-extraction', {
+      apiKey: 'test-key',
+      region: 'ca',
+    });
+
+    expect(service.getPromptTemplate).toHaveBeenCalledWith(
+      'bill-extraction',
+      'test-key',
+      'ca',
+    );
     expect(result).toEqual(expected);
   });
 });

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -29,6 +29,18 @@ import { BillVotesExtractionDto } from './dto/bill-votes-extraction.dto';
 const INVALID_API_KEY = 'Invalid API key';
 const TEMPLATE_NOT_FOUND = 'Template not found';
 
+// Per-route limit on prompt composition POSTs. 30/min default is generous
+// for a single legitimate node — comfortably above sustained scraping
+// cadence while bounding accidental loops. Configurable via
+// PROMPT_THROTTLE_LIMIT so integration test envs (which fire ~80 prompt
+// POSTs from a single container IP through a shared `default` throttler
+// bucket) can raise it without bypassing the production behavior tested
+// elsewhere. Mirrors ADMIN_THROTTLE_LIMIT and GLOBAL_THROTTLE_LIMIT.
+const PROMPT_THROTTLE_LIMIT = Number.parseInt(
+  process.env.PROMPT_THROTTLE_LIMIT ?? '30',
+  10,
+);
+
 function ApiPromptResponses() {
   return applyDecorators(
     ApiResponse({
@@ -51,7 +63,7 @@ export class PromptsController {
   constructor(private readonly promptsService: PromptsService) {}
 
   @Post('structural-analysis')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({ summary: 'Get structural analysis prompt' })
   @ApiPromptResponses()
   async structuralAnalysis(
@@ -66,7 +78,7 @@ export class PromptsController {
   }
 
   @Post('document-analysis')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({ summary: 'Get document analysis prompt' })
   @ApiPromptResponses()
   async documentAnalysis(
@@ -81,7 +93,7 @@ export class PromptsController {
   }
 
   @Post('rag')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({ summary: 'Get RAG prompt' })
   @ApiPromptResponses()
   async rag(
@@ -92,7 +104,7 @@ export class PromptsController {
   }
 
   @Post('civics-extraction')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({
     summary:
       'Get civics-extraction prompt. The LLM is instructed to emit a CivicsBlock with verbatim source text + plain-language rewrites for laypeople. See OpusPopuli/opuspopuli#669.',
@@ -110,7 +122,7 @@ export class PromptsController {
   }
 
   @Post('bill-extraction')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({
     summary:
       'Get bill-extraction prompt. The LLM is instructed to emit a structured Bill record from a single official legislature bill status page. See OpusPopuli/opuspopuli#686.',
@@ -128,7 +140,7 @@ export class PromptsController {
   }
 
   @Post('bill-votes-extraction')
-  @Throttle({ default: { ttl: 60_000, limit: 30 } })
+  @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({
     summary:
       'Get bill-votes-extraction prompt. The LLM is instructed to emit structured chamber-level roll-call vote records (per-member positions) from a billVotesClient page. See OpusPopuli/opuspopuli#686.',
@@ -174,5 +186,36 @@ export class PromptsController {
   @ApiResponse({ status: 404, description: TEMPLATE_NOT_FOUND })
   async hash(@Param('name') name: string) {
     return this.promptsService.getPromptHash(name);
+  }
+
+  /**
+   * Return the raw template payload (text + variables + metadata) for
+   * client-side caching and local interpolation. Designed to let clients
+   * stop calling the per-call composition endpoints on every bill/document
+   * — fetch once, cache for `expiresAt`, interpolate locally. A/B variants
+   * resolve server-side. See issue #66 and opuspopuli#729.
+   */
+  @Get(':name')
+  // 120/min: same as /:name/hash since this is also a cache-warmer endpoint
+  // that healthy clients hit infrequently (once per template per TTL window,
+  // not once per call).
+  @Throttle({ default: { ttl: 60_000, limit: 120 } })
+  @ApiOperation({
+    summary:
+      'Get the raw template payload for client-side caching + local interpolation',
+  })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Raw template + variables + hash + version + expiresAt + experiment context',
+  })
+  @ApiResponse({ status: 401, description: INVALID_API_KEY })
+  @ApiResponse({ status: 404, description: TEMPLATE_NOT_FOUND })
+  @ApiResponse({ status: 429, description: 'Rate limit exceeded' })
+  async template(
+    @Param('name') name: string,
+    @Req() req: { apiKey: string; region: string },
+  ) {
+    return this.promptsService.getPromptTemplate(name, req.apiKey, req.region);
   }
 }

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -435,6 +435,121 @@ describe('PromptsService', () => {
     });
   });
 
+  describe('getPromptTemplate (raw template fetch — issue #66)', () => {
+    it('returns raw template with variables, hash, version, and expiresAt', async () => {
+      const template = {
+        id: '1',
+        name: 'rag',
+        templateText: '{{CONTEXT}} {{QUERY}}',
+        version: 3,
+        isActive: true,
+        variables: ['CONTEXT', 'QUERY'],
+      };
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const result = await service.getPromptTemplate('rag', 'k', 'ca');
+
+      expect(result.name).toBe('rag');
+      expect(result.templateText).toBe('{{CONTEXT}} {{QUERY}}');
+      expect(result.variables).toEqual(['CONTEXT', 'QUERY']);
+      expect(result.promptVersion).toBe('v3');
+      expect(result.promptHash).toBe(
+        createHash('sha256').update('{{CONTEXT}} {{QUERY}}').digest('hex'),
+      );
+      expect(result.expiresAt).toBeDefined();
+      expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+      expect(result.experimentId).toBeNull();
+      expect(result.variantName).toBeNull();
+    });
+
+    it('logs the template-fetch audit entry with the per-template endpoint label', async () => {
+      const template = {
+        id: '1',
+        name: 'rag',
+        templateText: 't',
+        version: 1,
+        isActive: true,
+        variables: [],
+      };
+      prisma.promptTemplate.findFirst.mockResolvedValue(template);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      await service.getPromptTemplate('rag', 'my-secret-key', 'tx');
+
+      expect(prisma.promptRequestLog.create).toHaveBeenCalledWith({
+        data: {
+          endpoint: 'rag:template-fetch',
+          promptVersion: 1,
+          apiKeyPrefix: 'my-secre...',
+          region: 'tx',
+          experimentId: null,
+          variantName: null,
+        },
+      });
+    });
+
+    it('returns the A/B variant text when an experiment is active', async () => {
+      const baseTemplate = {
+        id: '1',
+        name: 'rag',
+        templateText: 'control text',
+        version: 1,
+        isActive: true,
+        variables: ['CONTEXT'],
+      };
+      experiments.resolveExperiment.mockResolvedValue({
+        templateText: 'variant text',
+        version: 5,
+        templateHash: 'h',
+        experimentId: 'exp-1',
+        variantName: 'variant_a',
+      });
+      prisma.promptTemplate.findFirst.mockResolvedValue(baseTemplate);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const result = await service.getPromptTemplate('rag', 'k', 'ca');
+
+      expect(result.templateText).toBe('variant text');
+      expect(result.promptVersion).toBe('v5');
+      // Variables come from the base template even when serving a variant —
+      // version_history doesn't carry them, but the client needs them to
+      // interpolate.
+      expect(result.variables).toEqual(['CONTEXT']);
+      expect(result.experimentId).toBe('exp-1');
+      expect(result.variantName).toBe('variant_a');
+    });
+
+    it('returns variant text and empty variables when base template is missing', async () => {
+      // Edge case: variant served but the canonical row was hard-deleted
+      // (or filter mismatch). Client gets an empty variable list rather
+      // than a 500.
+      experiments.resolveExperiment.mockResolvedValue({
+        templateText: 'variant text',
+        version: 2,
+        templateHash: 'h',
+        experimentId: 'exp-1',
+        variantName: 'control',
+      });
+      prisma.promptTemplate.findFirst.mockResolvedValue(null);
+      prisma.promptRequestLog.create.mockResolvedValue({});
+
+      const result = await service.getPromptTemplate('rag', 'k', 'ca');
+
+      expect(result.templateText).toBe('variant text');
+      expect(result.variables).toEqual([]);
+    });
+
+    it('throws NotFoundException when template does not exist (no experiment, no row)', async () => {
+      experiments.resolveExperiment.mockResolvedValue(null);
+      prisma.promptTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.getPromptTemplate('no-such-template', 'k', 'ca'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
   describe('verifyPrompt', () => {
     it('should return valid for a matching (hash, version) pair', async () => {
       const templateText = 'test template';

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -33,6 +33,23 @@ export interface PromptHashResult {
   promptVersion: string;
 }
 
+/**
+ * Raw template payload returned by `GET /prompts/:name` for client-side
+ * caching + local interpolation (issue #66). Includes everything a client
+ * needs to fill placeholders itself: text, variable list, hash, version,
+ * TTL, and A/B routing context.
+ */
+export interface PromptTemplateResponse {
+  name: string;
+  templateText: string;
+  variables: string[];
+  promptHash: string;
+  promptVersion: string;
+  expiresAt: string;
+  experimentId: string | null;
+  variantName: string | null;
+}
+
 interface ResolvedTemplate {
   templateText: string;
   version: number;
@@ -278,6 +295,56 @@ export class PromptsService implements OnModuleInit {
       name: template.name,
       promptHash: this.hash(template.templateText),
       promptVersion: `v${template.version}`,
+    };
+  }
+
+  /**
+   * Return the raw template payload for a named template — no interpolation.
+   *
+   * Designed for client-side caching (issue #66 + opuspopuli#729): the
+   * client holds the template + variables in memory for `expiresAt`, fills
+   * placeholders locally per call, and only re-fetches when the TTL passes
+   * or `/:name/hash` shows the cached hash is stale. Eliminates the per-call
+   * remote round-trip the prompt-client used to do per bill / per document.
+   *
+   * A/B experiments resolve server-side. The response carries
+   * experimentId/variantName so the caller can log the variant assignment
+   * for audit and analysis.
+   */
+  async getPromptTemplate(
+    name: string,
+    apiKey: string,
+    region: string,
+  ): Promise<PromptTemplateResponse> {
+    // resolveTemplate handles A/B routing. For the variant path it returns
+    // the variant text but no `variables` (those live on the canonical
+    // template row, not on version_history). Look up the base template
+    // separately so the caller always has the variable list — without it
+    // they can't interpolate locally.
+    const resolved = await this.resolveTemplate(name, apiKey);
+    const baseTemplate = await this.prisma.promptTemplate.findFirst({
+      where: { name, isActive: true },
+      select: { variables: true },
+    });
+
+    await this.logRequest(
+      `${name}:template-fetch`,
+      resolved.version,
+      apiKey,
+      region,
+      resolved.experimentId,
+      resolved.variantName,
+    );
+
+    return {
+      name,
+      templateText: resolved.templateText,
+      variables: baseTemplate?.variables ?? resolved.variables ?? [],
+      promptHash: this.hash(resolved.templateText),
+      promptVersion: `v${resolved.version}`,
+      expiresAt: this.buildExpiresAt(),
+      experimentId: resolved.experimentId ?? null,
+      variantName: resolved.variantName ?? null,
     };
   }
 
@@ -539,15 +606,17 @@ export class PromptsService implements OnModuleInit {
     templateText: string;
     version: number;
   }): PromptServiceResponse {
-    const ttlSeconds = this.config.get<number>('PROMPT_TTL_SECONDS', 3600);
-    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
-
     return {
       promptText: '',
       promptHash: this.hash(template.templateText),
       promptVersion: `v${template.version}`,
-      expiresAt,
+      expiresAt: this.buildExpiresAt(),
     };
+  }
+
+  private buildExpiresAt(): string {
+    const ttlSeconds = this.config.get<number>('PROMPT_TTL_SECONDS', 3600);
+    return new Date(Date.now() + ttlSeconds * 1000).toISOString();
   }
 
   private async logRequest(

--- a/test/integration/prompts/template.integration.spec.ts
+++ b/test/integration/prompts/template.integration.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * GET /prompts/:name — raw template fetch for client-side caching (#66).
+ *
+ * The companion client work in opuspopuli#729 consumes this endpoint to
+ * cache templates locally and stop calling the per-call composition
+ * endpoints once per bill/document. These tests pin the wire contract.
+ */
+import { createHash, createHmac } from 'node:crypto';
+import { apiGet, apiPost, get, post, hmacPost, adminPost } from '../utils';
+import { createTestNode, cleanupTestNodes } from '../utils/fixtures';
+import { BASE_URL, API_KEY } from '../utils/config';
+
+describe('GET /prompts/:name (template fetch) — integration', () => {
+  afterAll(async () => {
+    await cleanupTestNodes();
+  });
+
+  describe('Response contract', () => {
+    it('returns the raw template with variables, hash, version, and expiresAt', async () => {
+      const res = await apiGet('/prompts/rag');
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('rag');
+      expect(typeof res.body.templateText).toBe('string');
+      expect(res.body.templateText.length).toBeGreaterThan(0);
+      expect(Array.isArray(res.body.variables)).toBe(true);
+      expect(res.body.promptVersion).toMatch(/^v\d+$/);
+      expect(typeof res.body.promptHash).toBe('string');
+      expect(res.body.promptHash).toHaveLength(64);
+      expect(typeof res.body.expiresAt).toBe('string');
+      expect(new Date(res.body.expiresAt).getTime()).toBeGreaterThan(
+        Date.now(),
+      );
+      expect(res.body).toHaveProperty('experimentId');
+      expect(res.body).toHaveProperty('variantName');
+    });
+
+    it('`promptHash` matches `GET /:name/hash` (single source of truth)', async () => {
+      const tmpl = await apiGet('/prompts/bill-extraction');
+      const hashOnly = await apiGet('/prompts/bill-extraction/hash');
+
+      expect(tmpl.status).toBe(200);
+      expect(hashOnly.status).toBe(200);
+      expect(tmpl.body.promptHash).toBe(hashOnly.body.promptHash);
+      expect(tmpl.body.promptVersion).toBe(hashOnly.body.promptVersion);
+    });
+
+    it('`promptHash` equals the SHA-256 of the returned templateText', async () => {
+      // This is the contract the client relies on for cache invalidation:
+      // if the body changes, the hash must change.
+      const res = await apiGet('/prompts/rag');
+
+      expect(res.status).toBe(200);
+      const computed = createHash('sha256')
+        .update(res.body.templateText)
+        .digest('hex');
+      expect(res.body.promptHash).toBe(computed);
+    });
+
+    it('returns 404 for an unknown template', async () => {
+      const res = await apiGet('/prompts/this-template-does-not-exist');
+
+      expect(res.status).toBe(404);
+      expect(res.body.statusCode).toBe(404);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('requires authentication', async () => {
+      const res = await get('/prompts/rag');
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Local interpolation parity (the whole point of this endpoint)', () => {
+    it('local interpolation of the raw template equals the POST endpoint output', async () => {
+      // Fetch raw template, interpolate locally, and assert the result
+      // matches what the server-side composition endpoint produces.
+      // This is what `@opuspopuli/prompt-client` will do once it adopts
+      // the new endpoint (opuspopuli#729).
+      const tmpl = await apiGet('/prompts/rag');
+      expect(tmpl.status).toBe(200);
+
+      const variables = { CONTEXT: 'integration test context', QUERY: 'q?' };
+      const localRender = Object.entries(variables).reduce(
+        (text, [k, v]) => text.replaceAll(`{{${k}}}`, v),
+        tmpl.body.templateText as string,
+      );
+
+      const composed = await apiPost('/prompts/rag', {
+        body: { context: variables.CONTEXT, query: variables.QUERY },
+      });
+      expect(composed.status).toBe(201);
+
+      expect(composed.body.promptText).toBe(localRender);
+      // And the hash on both responses should match (they describe the
+      // same underlying template).
+      expect(composed.body.promptHash).toBe(tmpl.body.promptHash);
+    });
+  });
+
+  describe('HMAC accept-both-forms (#61 transitional)', () => {
+    let nodeId: string;
+    let nodeApiKey: string;
+
+    beforeAll(async () => {
+      const created = await createTestNode({
+        name: `integ-hmac-paths-${Date.now()}`,
+        region: 'ca',
+      });
+      expect(created.status).toBe(201);
+      nodeId = created.body.id;
+      nodeApiKey = created.body.apiKey;
+
+      await adminPost(`/admin/nodes/${nodeId}/certify`, {
+        body: { expiresInDays: 30 },
+      });
+    });
+
+    it('accepts a signed request via the existing hmacPost helper (canonical form)', async () => {
+      // hmacPost signs `/prompts/rag` with no query string, so canonical
+      // (originalUrl) equals legacy (path) and the request goes through
+      // the canonical branch.
+      const res = await hmacPost(
+        '/prompts/rag',
+        { context: 'hmac path canonical', query: 'q' },
+        nodeApiKey,
+        nodeId,
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('rejects a signed request whose path component does not match either form', async () => {
+      // Sign a body for /prompts/rag but send to a wrong path → signature
+      // computed against /prompts/wrong, server computes for /prompts/rag
+      // → neither matches.
+      const body = { context: 'wrong path', query: 'q' };
+      const bodyStr = JSON.stringify(body);
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const bodyHash = createHash('sha256').update(bodyStr).digest('hex');
+      const signatureString = `${timestamp}\nPOST\n/prompts/wrong\n${bodyHash}`;
+      const signature = createHmac('sha256', nodeApiKey)
+        .update(signatureString)
+        .digest('base64');
+
+      const res = await post('/prompts/rag', {
+        body,
+        headers: {
+          'x-hmac-signature': signature,
+          'x-hmac-timestamp': timestamp,
+          'x-hmac-key-id': nodeId,
+        },
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Real client smoke (uses BASE_URL directly)', () => {
+    it('is reachable at the published path', async () => {
+      // Sanity check that BASE_URL resolves and the endpoint shape is
+      // exactly what `@opuspopuli/prompt-client` will fetch.
+      const url = `${BASE_URL}/prompts/rag`;
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${API_KEY}` },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.templateText).toBeDefined();
+      expect(body.variables).toBeDefined();
+      expect(body.expiresAt).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Bundles the server-side work for #66 and #61 because both require coordinated changes in `@opuspopuli/prompt-client`. One client release (opuspopuli#729) ships canonical HMAC signing AND template caching; this PR is the server side that makes both possible without breaking currently-deployed clients.

### What's in this PR

- **`GET /prompts/:name`** — returns the raw template payload (`templateText`, `variables`, `promptHash`, `promptVersion`, `expiresAt`, `experimentId?`, `variantName?`). Lets clients cache templates locally and interpolate per call instead of hitting `POST /prompts/<endpoint>` for every bill/document. Resolves A/B experiments server-side; throttled at 120/min like `/:name/hash`. Audit-logged with endpoint label `<name>:template-fetch`. **Closes #66.**
- **HMAC path canonicalization in transitional mode** — guard accepts BOTH `req.originalUrl` (canonical, includes query string) AND `req.path` (legacy, no query) so currently-deployed clients keep working through the rollout. Logs `hmac_legacy_path_signature` when the legacy form is used so we know when it's safe to ship the follow-up PR (PR C below) that tightens to canonical-only. **#61 finding 1.**
- **`AdminKeyGuard` populates `req.adminKeyPrefix`** (8-char masked). Controllers consume the precomputed value instead of slicing the token in each handler. Removes 5 duplicated lines. **#61 finding 2.**
- **`SECURITY.md` documents `/metrics`** — the endpoint is intentionally unauthenticated for Prometheus and must be network-restricted at the deployment layer. Metric labels never include secrets. **#61 finding 3.**
- **`GLOBAL_THROTTLE_LIMIT` and `PROMPT_THROTTLE_LIMIT` env-configurable** — mirroring the `ADMIN_THROTTLE_LIMIT` pattern from #58. Lets integration test envs raise the gates (single container IP fires 100+ requests through a shared `default` throttler bucket) without changing production behavior. Production defaults unchanged.

### Why bundle #66 + #61

`@opuspopuli/prompt-client` needs BOTH the new endpoint AND the HMAC canonicalization in one release. Bundling here means one coordinated client release instead of two over a short window. The follow-up PR C (tighten HMAC to canonical-only) is the only piece that waits on client rollout.

## Test plan

- [x] **264 unit tests pass** (was 251 on develop, added 13: 5 for `getPromptTemplate`, 6 for HMAC transitional mode, 1 for `adminKeyPrefix`, 1 for the new controller route)
- [x] **118 integration tests pass** (was 109 on develop, added 9 in `test/integration/prompts/template.integration.spec.ts`)
- [x] `pnpm lint` — clean (extracted `verifyHmacSignature` helper to keep cognitive complexity under the SonarCloud gate)
- [x] `pnpm build` — clean
- [x] Coverage above 85/90/90/90 gates project-wide
- [x] **Live smoke against the rebuilt local stack:**
  - [x] `GET /prompts/rag` → returns `{name, templateText, variables: [CONTEXT, QUERY], promptVersion: v1, promptHash, expiresAt, experimentId: null, variantName: null}`
  - [x] `promptHash` from `GET /prompts/rag` exactly equals `promptHash` from `GET /prompts/rag/hash` (single source of truth)
  - [x] Local interpolation of the raw template **byte-equals** the server-side `POST /prompts/rag` `promptText` output (the whole point of the new endpoint)
  - [x] HMAC signing with path-only (legacy form) → 201 (transitional acceptance works)
  - [x] Admin audit log shows `performedBy: "admin-de..."` from the centralized guard
  - [x] Migration applied, no schema regressions, all 21 templates loaded

## Rollout sequence

**This PR (PR A):** server-side support — ship now.

**PR B — `OpusPopuli/opuspopuli` `@opuspopuli/prompt-client`:** consume the new endpoint with template cache (TTL honored via `expiresAt`, hash-revalidated), switch HMAC to canonical form. Tracks as `opuspopuli#729`. Can be in review concurrently with this PR but only merges after this one is deployed.

**PR C — prompt-service follow-up:** tighten HMAC to canonical-only after PR B has been rolled out and the `hmac_legacy_path_signature` metric drops to zero. Small PR, just removes the legacy fallback branch.

## Cross-links

- `OpusPopuli/prompt-service#66` — closes
- `OpusPopuli/prompt-service#61` — partial close (findings 1–3 done; PR C will tighten HMAC)
- `OpusPopuli/opuspopuli#729` — companion client work, depends on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)