### PR TITLE
chore: prettier formatting drift from local lint pass

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2055,7 +2055,7 @@ Self-check before output:
     name: 'committee-relevance-explanation',
     category: 'committee_relevance',
     description:
-      'One-sentence personalized "why this committee matters to you" narrative for a legislative committee, given the committee\'s structured jurisdictional facts (including which of the user\'s reps sit on it) + the user\'s anonymized declared signals. Output is the trust layer of the Committees Briefing section (opuspopuli#770 / #836 / #837). Consumed by the nightly batch job that caches `relevanceExplanation` per user/committee. See OpusPopuli/opuspopuli#834.',
+      "One-sentence personalized \"why this committee matters to you\" narrative for a legislative committee, given the committee's structured jurisdictional facts (including which of the user's reps sit on it) + the user's anonymized declared signals. Output is the trust layer of the Committees Briefing section (opuspopuli#770 / #836 / #837). Consumed by the nightly batch job that caches `relevanceExplanation` per user/committee. See OpusPopuli/opuspopuli#834.",
     variables: [
       'REGION_ID',
       'COMMITTEE_NAME',

--- a/src/prompts/dto/briefing-summary.dto.ts
+++ b/src/prompts/dto/briefing-summary.dto.ts
@@ -103,7 +103,7 @@ export class BriefingSummaryDto {
 
   @ApiProperty({
     description:
-      "Top-ranking axis on the highest-scoring bill — lets the LLM frame the stake of the top match (money/rights/services for `directMaterial`, topic alignment for `valuesAlignment`, time-sensitivity for `actionability`). Callers MUST omit this field when no bills exist; the rendered prompt receives the literal string `none` in that case. Sending the literal string `none` as the field value is rejected by the IsIn validator.",
+      'Top-ranking axis on the highest-scoring bill — lets the LLM frame the stake of the top match (money/rights/services for `directMaterial`, topic alignment for `valuesAlignment`, time-sensitivity for `actionability`). Callers MUST omit this field when no bills exist; the rendered prompt receives the literal string `none` in that case. Sending the literal string `none` as the field value is rejected by the IsIn validator.',
     enum: ['directMaterial', 'valuesAlignment', 'actionability'],
     required: false,
   })

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -204,7 +204,7 @@ export class PromptsController {
   @Throttle({ default: { ttl: 60_000, limit: PROMPT_THROTTLE_LIMIT } })
   @ApiOperation({
     summary:
-      "Get briefing-summary prompt. The LLM is instructed to emit a 2-3 sentence opening paragraph (30-60 words) for the user's `/me/briefing` page — a warm, descriptive narrative companion to the deterministic Phase 1 template. MUST be descriptive (\"here's what's open\"), NEVER persuasive (\"you should\"). Returns `{ paragraph: string }` or `{ skip: true, reason: string }`. Consumed by opuspopuli#849 Phase 2. See OpusPopuli/opuspopuli#849.",
+      'Get briefing-summary prompt. The LLM is instructed to emit a 2-3 sentence opening paragraph (30-60 words) for the user\'s `/me/briefing` page — a warm, descriptive narrative companion to the deterministic Phase 1 template. MUST be descriptive ("here\'s what\'s open"), NEVER persuasive ("you should"). Returns `{ paragraph: string }` or `{ skip: true, reason: string }`. Consumed by opuspopuli#849 Phase 2. See OpusPopuli/opuspopuli#849.',
   })
   @ApiPromptResponses()
   async briefingSummary(

--- a/src/prompts/prompts.service.spec.ts
+++ b/src/prompts/prompts.service.spec.ts
@@ -1590,14 +1590,10 @@ describe('PromptsService', () => {
       );
       // The actual name value lands in the fenced untrusted block
       // beneath the SECURITY NOTICE, NOT inline in metadata.
-      expect(result.promptText).toContain(
-        "## User's first name (untrusted",
-      );
+      expect(result.promptText).toContain("## User's first name (untrusted");
       expect(result.promptText).toContain('```text\nRodney\n```');
       expect(result.promptText).toContain('Bills on the briefing: 5');
-      expect(result.promptText).toContain(
-        'Representatives on the briefing: 7',
-      );
+      expect(result.promptText).toContain('Representatives on the briefing: 7');
       expect(result.promptText).toContain('Committees on the briefing: 5');
       expect(result.promptText).toContain('Propositions on the briefing: 1');
       expect(result.promptText).toContain(


### PR DESCRIPTION
Quote-style normalization the local linter applied after the initial push. No behavior change.