### PR TITLE
chore(infra): publish image to ghcr.io + add prod compose overlay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+# =============================================================================
+# Release — Build, Push, Sign & SBOM
+# =============================================================================
+#
+# Triggered on push to main (after CI passes). Builds the prompt-service Docker
+# image, pushes to GHCR, signs with Sigstore keyless cosign, and generates +
+# attaches an SPDX SBOM.
+#
+# Matches the opuspopuli monorepo release.yml shape so verification tooling and
+# pinned action SHAs are consistent across repos.
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: release-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/opuspopuli
+
+jobs:
+  build-sign-publish:
+    name: Build, Sign & Publish — prompt-service
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/prompt-service
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.IMAGE_PREFIX }}/prompt-service@${DIGEST}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/prompt-service@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-prompt-service.spdx.json
+
+      - name: Attest SBOM
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate sbom-prompt-service.spdx.json \
+            --type spdxjson \
+            "${{ env.IMAGE_PREFIX }}/prompt-service@${DIGEST}"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: sbom-prompt-service
+          path: sbom-prompt-service.spdx.json
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -216,11 +216,31 @@ prompt-service/
 │   └── main.ts                # Bootstrap + Swagger setup
 ├── postman/                   # Postman collection & environment
 ├── test/integration/          # Docker-based integration tests
-├── docker-compose.yml         # Local dev stack
+├── docker-compose.yml         # Local dev stack (builds from source)
 ├── docker-compose-integration.yml  # Integration test stack
-├── Dockerfile                 # Production image
-└── .github/workflows/ci.yml   # GitHub Actions CI
+├── docker-compose-prod.yml    # Production overlay (pulls ghcr.io/opuspopuli/prompt-service)
+├── Dockerfile                 # Production image (built by .github/workflows/release.yml)
+└── .github/workflows/
+    ├── ci.yml                 # PR lint + test
+    ├── release.yml            # Build + cosign sign + SBOM + push to ghcr.io on push to main
+    └── validate-main-pr.yml   # Pre-merge gate for main
 ```
+
+## Deployment
+
+Production images publish to `ghcr.io/opuspopuli/prompt-service` on push to `main` (cosign-signed with Sigstore keyless, SBOM attested). On the Mac Studio:
+
+```bash
+docker compose -f docker-compose-prod.yml pull
+docker compose -f docker-compose-prod.yml up -d
+```
+
+Pin a specific build for rollback:
+```bash
+TAG=sha-abc1234 docker compose -f docker-compose-prod.yml up -d
+```
+
+For local dev with hot reload, use `docker-compose.yml` (builds from source) or `pnpm start:dev` (no Docker).
 
 ## Prompt Templates
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,88 @@
+# =============================================================================
+# Docker Compose — Production (Mac Studio + Cloudflare Tunnel)
+# =============================================================================
+#
+# Runs alongside the opuspopuli stack on the Mac Studio. opuspopuli's prod
+# compose attaches to this stack's network (`prompt-service_default`) so its
+# `region` + `knowledge` services + `llm-rerank-worker` can reach the prompt
+# service at http://opuspopuli-prompts:3210.
+#
+# Image source: ghcr.io/opuspopuli/prompt-service — built and signed by
+# .github/workflows/release.yml on push to main. The Studio NEVER builds
+# locally; it pulls pre-built, cosign-signed images and runs them.
+#
+# Usage:
+#   docker compose -f docker-compose-prod.yml pull
+#   docker compose -f docker-compose-prod.yml up -d
+#   docker compose -f docker-compose-prod.yml logs -f opuspopuli-prompts
+#
+# For local dev with hot reload, use docker-compose.yml (build from source).
+# =============================================================================
+
+services:
+  opuspopuli-prompts-db:
+    image: supabase/postgres:17.6.1.091
+    container_name: opuspopuli-prompts-db
+    environment:
+      POSTGRES_DB: prompt_service
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${PROMPTS_DB_PASSWORD:-postgres}
+    ports:
+      - '5433:5432'
+    volumes:
+      - opuspopuli-prompts-db-data:/var/lib/postgresql/data
+      - ./supabase/roles.sql:/docker-entrypoint-initdb.d/ll-init-roles.sql:ro
+      - ./supabase/migrate.sh:/docker-entrypoint-initdb.d/migrate.sh:ro
+      - ./supabase/init.sql:/docker-entrypoint-initdb.d/zz-init-vault.sql:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+  opuspopuli-prompts:
+    image: ghcr.io/opuspopuli/prompt-service:${TAG:-latest}
+    container_name: opuspopuli-prompts
+    ports:
+      - '3210:3210'
+    environment:
+      DATABASE_URL: postgresql://postgres:${PROMPTS_DB_PASSWORD:-postgres}@opuspopuli-prompts-db:5432/prompt_service?schema=public
+      API_KEYS: ${PROMPT_SERVICE_API_KEYS}
+      ADMIN_API_KEYS: ${PROMPT_SERVICE_ADMIN_API_KEYS}
+      PROMPT_TTL_SECONDS: ${PROMPT_TTL_SECONDS:-3600}
+      HMAC_TIMESTAMP_TOLERANCE_SECONDS: ${HMAC_TIMESTAMP_TOLERANCE_SECONDS:-300}
+      # Swagger UI off in prod.
+      ENABLE_SWAGGER: 'false'
+      PORT: 3210
+    depends_on:
+      opuspopuli-prompts-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3210/health', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 256M
+
+volumes:
+  opuspopuli-prompts-db-data:
+    name: opuspopuli-prompts-db-data


### PR DESCRIPTION
## Summary

Pairs with the opuspopuli monorepo's ghcr.io workstream (PR coming separately) so the Mac Studio production host can pull both stacks from a registry instead of building. Before this change, prompt-service had no release workflow — the Studio would have to clone this repo and `docker compose build` to get a runnable image, which is the build-on-host pattern we're moving away from.

## What ships

- **`.github/workflows/release.yml`** — mirrors the opuspopuli release shape: build → push to `ghcr.io/opuspopuli/prompt-service` → cosign keyless sign → SPDX SBOM via syft → attach attestation. Same pinned action SHAs as opuspopuli's workflow so verification tooling is identical across both repos.
- **`docker-compose-prod.yml`** (new) — production overlay that pulls `ghcr.io/opuspopuli/prompt-service:${TAG:-latest}`. Existing `docker-compose.yml` is **untouched** so local dev (`build: .`, hot reload via `pnpm start:dev`) keeps working.
- **`README.md`** — file tree updated, new Deployment section with pull commands + `TAG=sha-…` rollback pin.

## Why now

ghcr.io was already wired for the 5 opuspopuli backend services; not extending the pattern to prompt-service would force the Studio into a hybrid model (pull most, build prompt-service) which is the worst of both worlds for the just-rewritten Mac Studio bootstrap runbook.

The Dockerfile takes no build-args (no private `@opuspopuli/*` packages), so the workflow is simpler than the opuspopuli matrix — single image, single job.

## Test plan

- [ ] CI lint + tests pass
- [ ] Confirm `release.yml` is wired by viewing the Actions tab (won't run until a push to `main`)
- [ ] After the promotion PR `develop → main` merges, verify `ghcr.io/opuspopuli/prompt-service:latest` is published with a cosign signature
- [ ] On the Mac Studio (post-bootstrap): `docker compose -f docker-compose-prod.yml pull && docker compose -f docker-compose-prod.yml up -d` succeeds and `:3210/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)